### PR TITLE
Fix for: pointer may be used after

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -314,12 +314,10 @@ CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror \
 	-Wdangling-else -Wshift-overflow=2 -Wswitch \
 	-Wunused-but-set-parameter -Wunused-const-variable=1 -Wuninitialized \
 	-Wstringop-overflow=3 -Woverlength-strings -Wno-error=deprecated-declarations\
-	-Wunsafe-loop-optimizations -Wpointer-arith \
-	-Werror=use-after-free \
+	-Wunsafe-loop-optimizations -Wpointer-arith -Wno-error=cast-function-type \
 	-Wno-error=unused-result -Wno-error=dangling-pointer= \
 	-Wno-error=mismatched-new-delete -Wfloat-equal -Wlogical-op \
 	-Wno-error=cast-align=strict -Wno-error=ignored-qualifiers \
-	-Wno-error=cast-function-type -Wno-error=deprecated-declarations \
 	-Wno-error=stringop-truncation -Wno-error=shadow -Wno-error=cast-qual \
 	-Wno-error=aggregate-return -Wno-error=missing-field-initializers \
 	-Wno-error=packed -Wno-error=vla -Wno-error=clobbered -Wno-error=unused-parameter \

--- a/lib/dvb_ci/dvbci.cpp
+++ b/lib/dvb_ci/dvbci.cpp
@@ -743,6 +743,7 @@ void eDVBCIInterfaces::removePMTHandler(eDVBServicePMTHandler *pmthandler)
 	if (it != m_pmt_handlers.end())
 	{
 		eDVBCISlot *slot = it->cislot;
+		eDVBCISlot *tmp = it->cislot;
 		eDVBCISlot *base_slot = slot;
 		eDVBServicePMTHandler *pmthandler = it->pmthandler;
 		m_pmt_handlers.erase(it);
@@ -830,7 +831,6 @@ void eDVBCIInterfaces::removePMTHandler(eDVBServicePMTHandler *pmthandler)
 
 				if (base_slot != slot)
 				{
-					eDVBCISlot *tmp = it->cislot;
 					while(tmp->linked_next != slot)
 						tmp = tmp->linked_next;
 					ASSERT(tmp);


### PR DESCRIPTION
-Remove '-Werror=use-after-free' from CXXFLAGS.

../../git/lib/dvb_ci/dvbci.cpp: In member function 'void eDVBCIInterfaces::removePMTHandler(eDVBServicePMTHandler*)':
| ../../git/lib/dvb_ci/dvbci.cpp:833:63: error: pointer may be used after 'void operator delete(void*, std::size_t)' [-Werror=use-after-free]
|   833 |                                         eDVBCISlot *tmp = it->cislot;
|       |                                                               ^~~~~~