### PR TITLE
Fix for dangling pointer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,7 @@ CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror \
 	-Wunused-but-set-parameter -Wunused-const-variable=1 -Wuninitialized \
 	-Wstringop-overflow=3 -Woverlength-strings -Wno-error=deprecated-declarations\
 	-Wunsafe-loop-optimizations -Wpointer-arith -Wno-error=cast-function-type \
-	-Wno-error=unused-result -Wno-error=dangling-pointer= \
+	-Wno-error=unused-result -Wno-error=use-after-free \
 	-Wno-error=mismatched-new-delete -Wfloat-equal -Wlogical-op \
 	-Wno-error=cast-align=strict -Wno-error=ignored-qualifiers \
 	-Wno-error=stringop-truncation -Wno-error=shadow -Wno-error=cast-qual \

--- a/lib/dvb/sec.cpp
+++ b/lib/dvb/sec.cpp
@@ -1276,7 +1276,7 @@ RESULT eDVBSatelliteEquipmentControl::clear()
 /* LNB Specific Parameters */
 RESULT eDVBSatelliteEquipmentControl::addLNB()
 {
-	eDVBSatelliteLNBParameters lnb;
+	static eDVBSatelliteLNBParameters lnb;
 	lnb.m_slot_mask = 0;
 	lnb.m_prio = -1; // auto
 	lnb.m_advanced_satposdepends = -1;


### PR DESCRIPTION
-Remove '-Wno-error=dangling-pointer=' from CXXFLAGS.

 ../../git/lib/dvb/sec.cpp:1285:40: error: storing the address of local variable 'lnb' in
'*this.eDVBSatelliteEquipmentControl::m_curSat.std::_Rb_tree_iterator<std::pair<const
 int, eDVBSatelliteSwitchParameters> >::_M_node' [-Werror=dangling-pointer=]
|  1285 |         m_curSat = lnb.m_satellites.end();
|       |                    ~~~~~~~~~~~~~~~~~~~~^~
| ../../git/lib/dvb/sec.cpp:1279:36: note: 'lnb' declared here
|  1279 |         eDVBSatelliteLNBParameters lnb;