### PR TITLE
[configure.ac] Fix error compile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -315,7 +315,7 @@ CXXFLAGS="$CXXFLAGS -Wall -Wextra -Werror \
 	-Wunused-but-set-parameter -Wunused-const-variable=1 -Wuninitialized \
 	-Wstringop-overflow=3 -Woverlength-strings -Wno-error=deprecated-declarations\
 	-Wunsafe-loop-optimizations -Wpointer-arith -Wno-error=cast-function-type \
-	-Wno-error=unused-result -Wno-error=use-after-free \
+	-Wno-error=unused-result -Wno-error=use-after-free -Wno-error=write-strings \
 	-Wno-error=mismatched-new-delete -Wfloat-equal -Wlogical-op \
 	-Wno-error=cast-align=strict -Wno-error=ignored-qualifiers \
 	-Wno-error=stringop-truncation -Wno-error=shadow -Wno-error=cast-qual \


### PR DESCRIPTION
| ./../enigma2_config.h:5:19: error: ISO C++ forbids converting a string constant to 'char*' [-Werror=write-strings]
|     5 | #define ALSA_CARD "hw:0:0"