### PR TITLE
[DNS] Update code .

### DIFF
--- a/lib/python/Components/Network.py
+++ b/lib/python/Components/Network.py
@@ -139,12 +139,15 @@ class Network:
 
 	def writeNameserverConfig(self):
 		try:
-			fp = open('/etc/resolv.conf', 'w')
-			for nameserver in self.nameservers:
-				fp.write("nameserver %d.%d.%d.%d\n" % tuple(nameserver))
-			fp.close()
-			if config.usage.dns.value.lower() not in ("dhcp-router", "custom"):
-				fp = open('/etc/enigma2/nameserversdns.conf', 'w')
+			if config.usage.dns.value.lower() in ("dhcp-router", "staticip"):
+				fp = open('/etc/resolv.conf', 'w')
+				for nameserver in self.nameservers:
+					fp.write("nameserver %d.%d.%d.%d\n" % tuple(nameserver))
+				fp.close()
+				if (os.path.isfile("/etc/enigma2/nameservers")):
+					Console().ePopen('rm /etc/enigma2/nameservers')
+			else:
+				fp = open('/etc/enigma2/nameservers', 'w')
 				for nameserver in self.nameservers:
 					fp.write("nameserver %d.%d.%d.%d\n" % tuple(nameserver))
 				fp.close()
@@ -203,8 +206,7 @@ class Network:
 			self.configuredNetworkAdapters = self.configuredInterfaces
 			# load ns only once
 			self.loadNameserverConfig()
-			if config.usage.dns.value.lower() not in ("dhcp-router", "custom"):
-				self.writeNameserverConfig()
+			self.writeNameserverConfig()
 			print("[Network] read configured interface:", ifaces)
 			# remove any password before info is printed to the debug log
 			safe_ifaces = self.ifaces.copy()
@@ -224,12 +226,10 @@ class Network:
 
 		resolv = []
 		try:
-			if config.usage.dns.value.lower() in ("dhcp-router", "custom"):
+			if config.usage.dns.value.lower() in ("dhcp-router", "staticip"):
 				fp = open('/etc/resolv.conf', 'r')
-				if (isfile("/etc/enigma2/nameserversdns.conf")):
-					Console().ePopen('rm /etc/enigma2/nameserversdns.conf')
 			else:
-				fp = open('/etc/enigma2/nameserversdns.conf', 'r')
+				fp = open('/etc/enigma2/nameservers', 'r')
 			resolv = fp.readlines()
 			fp.close()
 			self.nameservers = []


### PR DESCRIPTION
- Added introductions of actions with DHCP or Static IP Router.
- The file is changed to a more logical one when opening-writing other DNS servers.
- DNS server list is updateable for other servers, two new DNS servers are added. Quad9 Security - Quad9 No Security
-Actions are eliminated for users to remove or add DNS, this is written by the list of servers (it will be updated).
- NetworkSetup.py: define keyMenu class NameserverSetup

Co-authored-by: norhap <elfogondesegovia@gmail.com>

******************

DNSSettings: Use "dhcp-router" "staticip" values in real time
- I move this code from UsageConfig.
- Now we see in real time what type of DHCP or Static IP configuration we have chosen in the adapter.
- Introduction is improved, for navigation keys, value current used dns.

******************

NetworkSetup.py: add in introduction dns and server name current
- Solved problems for index list save getCurrent and cancel.
- I use Setup keySave.
- config dns save is deleted.


Depend on OpenVision source