### PR TITLE
 [ConfigList/Setup UI]

### DIFF
--- a/data/menu.xml
+++ b/data/menu.xml
@@ -48,7 +48,7 @@
 				<menu key="video" level="0" text="Audio &amp; Video">
 					<item key="av_setup" level="0"><setup id="avsetup"/></item>
 					<item key="subtitle_setup" level="2" text="Subtitle Setup" weight="20"><setup id="subtitlesetup" /></item>
-					<item key="autolanguage_setup" level="0"text="Auto Language Setup"><setup id="autolanguagesetup"/></item>
+					<item key="autolanguage_setup" level="0" text="Auto Language Setup"><setup id="autolanguagesetup"/></item>
 					<item key="osdsetup" level="1" text="OSD Calibration" weight="50" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSDCalibration" /></item>
 					<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSD3DCalibration"><screen module="OSDCalibration" screen="OSD3DCalibration" /></item>
 				</menu>

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -1,83 +1,80 @@
-<menu text="Main menu" title="Main menu">
-	<id val="mainmenu"/>
-<!-- the following types are allowed:
+<menu key="mainmenu" text="Main menu">
+<!--
+	The following types are allowed:
 	<screen [module="mod"] [screen="classname"]>[arguments]</screen>
-		executes Screen called "classname" from module "Screen.mod"
-		if no module is given, Screen must be globally available.
-		if no screen is given, module is used as screen class name.
-		arguments must be comma seperated (will be fed to eval), and can
-			use stuff from module
-		(of course you must specify at least one of module, screen.)
-	<setup id="id"/>
-		opens a setup with specified id
+		Executes Screen called "classname" from module "Screen.mod".
+		If no module is given, Screen must be globally available.
+		If no screen is given, module is used as screen class name.
+		Arguments must be comma seperated (will be fed to eval), and can
+			use stuff from module.
+		(Of course you must specify at least one of module, screen.)
+	<plugin [extensions/system="pluginname"] [screen="classname"]>[arguments]</plugin>
+		Either "extensions" or "system" must be used. "extensions" is for 
+		Plugin.Extensions plugins and "system" is for Plugins.SystemPlugins.
+	<plugin [extensions="pluginname"] [screen="classname"]>[arguments]</plugin>
+		Executes Screen called "classname" from module "Plugins.Extensions.pluginname.plugin".
+		If no screen is given, "pluginname" is used as screen class name.
+		Arguments must be comma seperated (will be fed to eval), and can
+			use stuff from module.
+	<setup id="id" />
+		Opens a setup with specified id.
 	<code> .. code .. </code>
-		"exec"s code
+		Python "exec"s code.
 -->
-		<menu weight="7" level="0" text="Timers" entryID="timer_menu">
-			<id val="timermenu" />
-			<item weight="0" level="0" text="Timers" entryID="timer_edit"><screen module="TimerEdit" screen="TimerEditList" /></item>
-			<item weight="10" level="0" text="CronTimers" entryID="crontimer_edit"><screen module="CronTimer" screen="CronTimers" /></item>
+		<menu key="timermenu" weight="7" level="0" text="Timers">
+			<item key="timer_edit" weight="0" level="0" text="Timers"><screen module="TimerEdit" screen="TimerEditList" /></item>
+			<item key="crontimer_edit" weight="10" level="0" text="CronTimers"><screen module="CronTimer" screen="CronTimers" /></item>
 		</menu>
-		<item level="1" text="VCR scart" entryID="scart_switch" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch"><code>self.session.scart.VCRSbChanged(3)</code></item>
+		<item key="scart_switch" level="1" text="VCR scart" conditional="config.usage.show_vcr_scart.value" requires="ScartSwitch"><code>self.session.scart.VCRSbChanged(3)</code></item>
 
-		<menu level="0" text="Information" entryID="info_screen">
-			<id val="information"/>
-			<item level="1" text="Service" entryID="service_info_screen"><screen module="ServiceInfo" screen="ServiceInfo"/></item>
-			<item level="0" text="About" entryID="about_screen"><screen module="About"/></item>
-			<item level="2" text="Streaming clients info" entryID="streaming_clients_info_screen"><screen module="StreamingClientsInfo"/></item>
+		<menu key="information" level="0" text="Information">
+			<item key="service_info_screen" level="1" text="Service"><screen module="ServiceInfo" screen="ServiceInfo"/></item>
+			<item key="about_screen" level="0" text="About"><screen module="About"/></item>
+			<item key="streaming_clients_info_screen" level="2" text="Streaming clients info"><screen module="StreamingClientsInfo"/></item>
 		</menu>
 
-		<item level="0" text="Plugins" entryID="plugin_selection"><screen module="PluginBrowser" screen="PluginBrowser"/></item>
-		<menu level="0" text="Setup" flushConfigOnClose="1" entryID="setup_selection" >
-			<id val="setup"/>
-			<menu weight="7" level="0" text="Tuners &amp; scanning" entryID="service_searching_selection">
-				<id val="scan"/>
-				<item text="Tuner configuration" entryID="tuner_setup" conditional="nimmanager.nim_slots"><screen module="Satconfig" screen="NimSelection"/></item>
-				<item text="Automatic scan" entryID="auto_scan" conditional="nimmanager.somethingConnected()"><screen module="ScanSetup" screen="ScanSimple"/></item>
-				<item text="Manual scan" entryID="manual_scan" conditional="nimmanager.somethingConnected()"><screen module="ScanSetup"/></item>
-				<item text="Fallback remote receiver setup" entryID="fallbacktuner_settings"><screen module="SetupFallbacktuner"/></item>
+		<item key="plugin_selection" level="0" text="Plugins"><screen module="PluginBrowser" screen="PluginBrowser"/></item>
+		<menu key="setup" level="0" text="Setup" flushConfigOnClose="1">
+			<menu key="scan" weight="7" level="0" text="Tuners &amp; scanning">
+				<item key="tuner_setup"  text="Tuner configuration" conditional="nimmanager.nim_slots"><screen module="Satconfig" screen="NimSelection"/></item>
+				<item key="auto_scan"  text="Automatic scan" conditional="nimmanager.somethingConnected()"><screen module="ScanSetup" screen="ScanSimple"/></item>
+				<item key="manual_scan" text="Manual scan" conditional="nimmanager.somethingConnected()"><screen module="ScanSetup"/></item>
+				<item key="fallbacktuner_settings" text="Fallback remote receiver setup"><screen module="SetupFallbacktuner"/></item>
 			</menu>
-			<menu weight="5" level="0" text="System" entryID="system_selection">
-				<id val="system"/>
-				<menu weight="0" level="0" text="Check update Settings" entryID="check_update">
-					<id val="update"/>
-					<item level="0" entryID="check_update"><setup id="checkupdate"/></item>
+			<menu key="system" weight="5" level="0" text="System">
+				<menu key="update" weight="0" level="0" text="Check update Settings">
+					<item key="check_update" level="0"><setup id="checkupdate"/></item>
 				</menu>
-				<menu level="0" text="Audio &amp; Video" entryID="video_selection">
-					<id val="video"/>
-					<item level="0" entryID="av_setup"><setup id="avsetup"/></item>
-					<item entryID="subtitle_setup" level="2" text="Subtitle Setup" weight="20"><setup id="subtitlesetup" /></item>
-					<item level="0" entryID="autolanguage_setup" text="Auto Language Setup"><setup id="autolanguagesetup"/></item>
-					<item entryID="osdsetup" level="1" text="OSD Calibration" weight="50" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSDCalibration" /></item>
-					<item entryID="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSD3DCalibration"><screen module="OSDCalibration" screen="OSD3DCalibration" /></item>
+				<menu key="video" level="0" text="Audio &amp; Video">
+					<item key="av_setup" level="0"><setup id="avsetup"/></item>
+					<item key="subtitle_setup" level="2" text="Subtitle Setup" weight="20"><setup id="subtitlesetup" /></item>
+					<item key="autolanguage_setup" level="0"text="Auto Language Setup"><setup id="autolanguagesetup"/></item>
+					<item key="osdsetup" level="1" text="OSD Calibration" weight="50" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSDCalibration" /></item>
+					<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSD3DCalibration"><screen module="OSDCalibration" screen="OSD3DCalibration" /></item>
 				</menu>
-				<menu level="0" text="GUI Settings" entryID="gui_settings">
-					<id val="gui"/>
-					<item level="0" text="Language" entryID="language_setup"><screen module="LanguageSelection"/></item>
+				<item key="usage_setup" level="0" text="Customize"><setup id="usage"/></item>
+				<menu key="gui" level="0" text="GUI Settings">
+					<item key="language_setup" level="0" text="Language"><screen module="LanguageSelection"/></item>
 					<!-- Menu / Setup / Time -->
-					<item entryID="time_setup" level="0" text="Time" weight="50"><screen module="Time" screen="Time" /></item>
-					<item level="0" entryID="user_interface" text="User Interface" ><setup id="userinterface"/></item>
-					<item level="0" entryID="usage_setup"><setup id="usage"/></item>
-					<item level="0" text="Skin" entryID="primary_skin_selector"><screen module="SkinSelector" screen="SkinSelector"/></item>
-					<menu entryID="display_selection" level="0" text="Front Panel Display">
-						<id val="lcd" />
-						<item entryID="display_skin_selector" level="0" text="Skin Setup" weight="5" requires="Display"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
-						<item entryID="lcd_setup" level="1" text="LCD Setup" weight="10" requires="Display"><setup id="FrontDisplay" /></item>
-						<item entryID="led_setup" level="1" text="LED Setup" weight="15"><setup id="LedDisplay" /></item>
+					<item key="time_setup" level="0" text="Time" weight="50"><screen module="Time" screen="Time" /></item>
+					<item key="user_interface" level="0" text="User Interface" ><setup id="userinterface"/></item>
+					<item key="usage_setup" level="0" ><setup id="usage"/></item>
+					<item key="primary_skin_selector" level="0" text="Skin"><screen module="SkinSelector" screen="SkinSelector"/></item>
+					<menu key="lcd" level="0" text="Front Panel Display">
+						<item key="display_skin_selector" level="0" text="Skin Setup" weight="5" requires="Display"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
+						<item key="lcd_setup" level="1" text="LCD Setup" weight="10" requires="Display"><setup id="FrontDisplay" /></item>
+						<item key="led_setup" level="1" text="LED Setup" weight="15"><setup id="LedDisplay" /></item>
 					</menu>
 				</menu>
-				<menu entryID="usage_setup" level="0" text="Log Manager" weight="2">
-					<id val="logs_menu" />
-					<item entryID="logs_setup" level="2" text="Settings"><setup id="Logs" /></item>
-					<item entryID="logs_man" level="2" text="View Log Manager"><screen module="LogManager" screen="LogManager" /></item>
+				<menu key="logs_menu" level="0" text="Log Manager" weight="2">
+					<item key="logs_setup" level="2" text="Settings"><setup id="Logs" /></item>
+					<item key="logs_man" level="2" text="View Log Manager"><screen module="LogManager" screen="LogManager" /></item>
 				</menu>
 				<!-- Menu / Setup / EPG -->
-				<menu entryID="epg_menu" level="0" text="EPG" weight="15">
-					<id val="epg" />
-					<item entryID="epg_setup" level="0" text="EPG Setup" weight="5"><setup id="EPG" /></item>
-					<menu entryID="epgloadsave_menu" level="2" text="Save, Load &amp; Delete EPG Cache" weight="10">
-						<id val="epgloadsave_menu" />
-						<item entryID="saveepgcache" level="0" text="Save EPG Cache">
+				<menu key="epg" level="0" text="EPG" weight="15">
+					<item key="epg_setup" level="0" text="EPG Setup" weight="5"><setup id="EPG" /></item>
+					<menu key="epgloadsave_menu" level="2" text="Save, Load &amp; Delete EPG Cache" weight="10">
+						<item key="saveepgcache" level="0" text="Save EPG Cache">
 							<code>
 from Components.EpgLoadSave import EpgSaveMsg
 def msgClosed(ret):
@@ -88,7 +85,7 @@ def msgClosed(ret):
 self.session.openWithCallback(msgClosed, EpgSaveMsg)
 							</code>
 						</item>
-						<item entryID="loadepgcache" level="0" text="Load EPG Cache">
+						<item key="loadepgcache" level="0" text="Load EPG Cache">
 							<code>
 from Components.EpgLoadSave import EpgLoadMsg
 def msgClosed(ret):
@@ -99,7 +96,7 @@ def msgClosed(ret):
 self.session.openWithCallback(msgClosed, EpgLoadMsg)
 							</code>
 						</item>
-						<item entryID="deleteepgcache" level="0" text="Delete EPG Cache">
+						<item key="deleteepgcache" level="0" text="Delete EPG Cache">
 							<code>
 from Components.EpgLoadSave import EpgDeleteMsg
 def msgClosed(ret):
@@ -116,60 +113,55 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 						</item>
 					</menu>
 				</menu>
-				<item level="1" entryID="rfmod_setup" requires="RfModulator"><setup id="RFmod"/></item>
-				<menu level="0" text="Expert settings" entryID="expert_selection">
-				<id val="expert"/>
-				<item level="0" entryID="accesslevel_setup"><setup id="accesslevel"/></item>
+				<item key="rfmod_setup" level="1" requires="RfModulator"><setup id="RFmod"/></item>
+				<menu key="expert" level="0" text="Expert settings">
+				<item key="accesslevel_setup" level="0"><setup id="accesslevel"/></item>
 				<!-- Menu / Setup / Recordings, Playback & Timeshift -->
-				<menu entryID="rec_setup" level="1" text="Playback, Recording &amp; Timeshift" weight="45">
-					<id val="rec" />
-					<item entryID="playback_setup" level="0" text="Playback Setup" weight="5"><setup id="Playback" /></item>
-					<item entryID="recording_setup" level="0" text="Recording Setup" weight="10"><screen module="Recording" screen="RecordingSettings" /></item>
-					<item entryID="timeshift_setup" level="0" text="Timeshift Setup" weight="15"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
-					<item entryID="hdmirecord_setup" level="0" text="HDMI-IN Recording settings" weight="15" requires="HDMIin"><setup id="HDMIRecord"/></item>
+				<menu key="rec" level="1" text="Playback, Recording &amp; Timeshift" weight="45">
+					<item key="playback_setup" level="0" text="Playback Setup" weight="5"><setup id="Playback" /></item>
+					<item key="recording_setup" level="0" text="Recording Setup" weight="10"><screen module="Recording" screen="RecordingSettings" /></item>
+					<item key="timeshift_setup" level="0" text="Timeshift Setup" weight="15"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
+					<item key="hdmirecord_setup" level="0" text="HDMI-IN Recording settings" weight="15" requires="HDMIin"><setup id="HDMIRecord"/></item>
 				</menu>
-				<menu level="0" text="Harddisk" entryID="hardisk_selection" requires="Harddisk">
-					<id val="harddisk"/>
-					<item level="0" entryID="harddisk_setup"><setup id="harddisk"/></item>
-					<item level="0" text="Initialization" entryID="harddisk_init"><screen module="HarddiskSetup" screen="HarddiskSelection"/></item>
-					<item level="0" text="Filesystem check" entryID="harddisk_check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection"/></item>
-					<item entryID="flash_expander" level="2" text="Flash Expander" weight="40"><screen module="FlashExpander" screen="FlashExpander" /></item>
+				<menu key="harddisk" level="0" text="Harddisk" requires="Harddisk">
+					<item key="harddisk_setup" level="0"><setup id="harddisk"/></item>
+					<item key="harddisk_init" level="0" text="Initialization"><screen module="HarddiskSetup" screen="HarddiskSelection"/></item>
+					<item key="harddisk_check" level="0" text="Filesystem check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection"/></item>
+					<item key="flash_expander" level="2" text="Flash Expander" weight="40"><screen module="FlashExpander" screen="FlashExpander" /></item>
 				</menu>
-				<item level="0" text="Network" entryID="network_setup"><screen module="NetworkSetup" screen="NetworkAdapterSelection"/></item>
-				<item level="1" text="Input devices" entryID="input_device_setup"><screen module="InputDeviceSetup" screen="InputDeviceSelection"/></item>
-				<item entryID="keyboard_setup" text="Keyboard"><setup id="keyboard"/></item>
-				<item level="1" text="Hotkey" entryID="hotkey_setup"><screen module="Hotkey" screen="HotkeySetup"/></item>
+				<item key="network_setup" level="0" text="Network"><screen module="NetworkSetup" screen="NetworkAdapterSelection"/></item>
+				<item key="input_device_setup" level="1" text="Input devices"><screen module="InputDeviceSetup" screen="InputDeviceSelection"/></item>
+				<item key="keyboard_setup" text="Keyboard"><setup id="keyboard"/></item>
+				<item key="hotkey_setup" level="1" text="Hotkey"><screen module="Hotkey" screen="HotkeySetup"/></item>
 				</menu>
 			</menu>
 
-			<menu weight="10" text="SoftCam / CI" entryID="cam_setup">
-				<id val="cam"/>
-				<item weight="10" level="0" text="Softcam Setup" entryID="softcam_setup"><screen module="SoftcamSetup" screen="SoftcamSetup"/></item>
-				<item weight="10" level="0" text="Common Interface" entryID="ci_setup" requires="CommonInterface"><screen module="Ci" screen="CiSelection"/></item>
-				<item weight="110" level="2" text="Stream Relay Settings" entryID="streamrelay_settings"><screen module="SoftcamSetup" screen="StreamRelaySetup" /></item>
+			<menu key="cam" weight="10" text="SoftCam / CI">
+				<item key="softcam_setup" weight="10" level="0" text="Softcam Setup"><screen module="SoftcamSetup" screen="SoftcamSetup"/></item>
+				<item key="ci_setup" weight="10" level="0" text="Common Interface" requires="CommonInterface"><screen module="Ci" screen="CiSelection"/></item>
+				<item key="streamrelay_settings" weight="110" level="2" text="Stream Relay Settings"><screen module="SoftcamSetup" screen="StreamRelaySetup" /></item>
 			</menu>
 
-			<item weight="15" level="0" text="Parental control" entryID="parental_setup"><screen module="ParentalControlSetup" screen="ParentalControlSetup"/></item>
-			<item weight="15" level="0" text="Factory reset" entryID="factory_reset"><screen module="FactoryReset" screen="FactoryReset"/></item>
-			<!--item entryID="flash_online" level="0" text="Flash image Online" description="Download and flash images on your device." weight="13"><screen module="FlashManager" screen="FlashManager" /></item-->
-			<!--item weight="15" level="0" text="Software update" entryID="software_update"><screen module="SoftwareUpdate" screen="UpdatePlugin"/></item-->
+			<item key="parental_setup" weight="15" level="0" text="Parental control"><screen module="ParentalControlSetup" screen="ParentalControlSetup"/></item>
+			<item key="factory_reset" weight="15" level="0" text="Factory reset"><screen module="FactoryReset" screen="FactoryReset"/></item>
+			<!--item key="flash_online" level="0" text="Flash image Online" description="Download and flash images on your device." weight="13"><screen module="FlashManager" screen="FlashManager" /></item-->
+			<!--item key="software_update" weight="15" level="0" text="Software update"><screen module="SoftwareUpdate" screen="UpdatePlugin"/></item-->
 		</menu>
 
-		<menu text="Standby / restart" entryID="standby_restart_list">
-			<id val="shutdown"/>
-			<item text="Sleep timer" entryID="sleep"><screen module="SleepTimerEdit" screen="SleepTimerEdit"/></item>
-			<item text="Standby" entryID="standby"><screen module="Standby" screen="Standby"/></item>
-			<item text="Full Restart" entryID="restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
-			<item weight="24" level="0" text="Switch to Android" requires="canDualBoot" entryID="dualboot"><screen module="Standby" screen="SwitchToAndroid" /></item>
-			<!--item text="Restart enigma" requires="InDebugMode" entryID="restart_enigma_debug"><screen module="Standby" screen="TryQuitMainloop">6</screen></item>
-			<item text="Restart enigma" requires="!InDebugMode" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item-->
-			<item text="Restart enigma" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
-			<!--item text="Restart enigma in standard mode" requires="InDebugMode" entryID="restart_enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
-			<item text="Restart enigma in debug mode" requires="!InDebugMode" entryID="restart_enigma_debug"><screen module="Standby" screen="TryQuitMainloop">6</screen></item-->
-			<item entryID="multiboot" level="0" text="MultiBoot Manager" weight="6" requires="canMultiBoot"><screen module="MultiBootManager" screen="MultiBootManager" /></item>
-			<item entryID="kexec_multiboot" level="2" text="Enable Kexec MultiBoot" weight="6" requires="cankexec"><screen module="MultiBootManager" screen="KexecInit">1</screen></item>
-			<item text="Deep standby" requires="DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
-			<item text="Shutdown" requires="!DeepstandbySupport" entryID="deep_standby"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
-			<item entryID="maintenance_mode" level="0" text="Recovery Mode" weight="55" requires="RecoveryMode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
+		<menu key="shutdown" text="Standby / restart">
+			<item key="sleep" text="Sleep timer"><screen module="SleepTimerEdit" screen="SleepTimerEdit"/></item>
+			<item key="standby" text="Standby"><screen module="Standby" screen="Standby"/></item>
+			<item key="restart" text="Full Restart"><screen module="Standby" screen="TryQuitMainloop">2</screen></item>
+			<item key="dualboot" weight="24" level="0" text="Switch to Android" requires="canDualBoot"><screen module="Standby" screen="SwitchToAndroid" /></item>
+			<!--item key="restart_enigma_debug" text="Restart enigma" requires="InDebugMode"><screen module="Standby" screen="TryQuitMainloop">6</screen></item>
+			<item key="restart_enigma" text="Restart enigma" requires="!InDebugMode"><screen module="Standby" screen="TryQuitMainloop">3</screen></item-->
+			<item key="restart_enigma" text="Restart enigma"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
+			<!--item key="restart_enigma" text="Restart enigma in standard mode" requires="InDebugMode"><screen module="Standby" screen="TryQuitMainloop">3</screen></item>
+			<item key="restart_enigma_debug" text="Restart enigma in debug mode" requires="!InDebugMode"><screen module="Standby" screen="TryQuitMainloop">6</screen></item-->
+			<item key="multiboot" level="0" text="MultiBoot Manager" weight="6" requires="canMultiBoot"><screen module="MultiBootManager" screen="MultiBootManager" /></item>
+			<item key="kexec_multiboot" level="2" text="Enable Kexec MultiBoot" weight="6" requires="cankexec"><screen module="MultiBootManager" screen="KexecInit">1</screen></item>
+			<item key="deep_standby" text="Deep standby" requires="DeepstandbySupport"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
+			<item key="deep_standby" text="Shutdown" requires="!DeepstandbySupport"><screen module="Standby" screen="TryQuitMainloop">1</screen></item>
+			<item key="maintenance_mode" level="0" text="Recovery Mode" weight="55" requires="RecoveryMode"><screen module="Standby" screen="TryQuitMainloop">16</screen></item>
 		</menu>
 </menu>

--- a/data/menu.xml
+++ b/data/menu.xml
@@ -52,13 +52,12 @@
 					<item key="osdsetup" level="1" text="OSD Calibration" weight="50" requires="OSDCalibration"><screen module="OSDCalibration" screen="OSDCalibration" /></item>
 					<item key="setup_osd3d" level="2" text="OSD 3D Settings" weight="60" requires="OSD3DCalibration"><screen module="OSDCalibration" screen="OSD3DCalibration" /></item>
 				</menu>
-				<item key="usage_setup" level="0" text="Customize"><setup id="usage"/></item>
 				<menu key="gui" level="0" text="GUI Settings">
 					<item key="language_setup" level="0" text="Language"><screen module="LanguageSelection"/></item>
 					<!-- Menu / Setup / Time -->
 					<item key="time_setup" level="0" text="Time" weight="50"><screen module="Time" screen="Time" /></item>
 					<item key="user_interface" level="0" text="User Interface" ><setup id="userinterface"/></item>
-					<item key="usage_setup" level="0" ><setup id="usage"/></item>
+					<item key="usage_setup" level="0" text="Customize"><setup id="usage"/></item>
 					<item key="primary_skin_selector" level="0" text="Skin"><screen module="SkinSelector" screen="SkinSelector"/></item>
 					<menu key="lcd" level="0" text="Front Panel Display">
 						<item key="display_skin_selector" level="0" text="Skin Setup" weight="5" requires="Display"><screen module="SkinSelector" screen="LcdSkinSelector" /></item>
@@ -115,24 +114,24 @@ self.session.openWithCallback(msgClosed, EpgDeleteMsg)
 				</menu>
 				<item key="rfmod_setup" level="1" requires="RfModulator"><setup id="RFmod"/></item>
 				<menu key="expert" level="0" text="Expert settings">
-				<item key="accesslevel_setup" level="0"><setup id="accesslevel"/></item>
-				<!-- Menu / Setup / Recordings, Playback & Timeshift -->
-				<menu key="rec" level="1" text="Playback, Recording &amp; Timeshift" weight="45">
-					<item key="playback_setup" level="0" text="Playback Setup" weight="5"><setup id="Playback" /></item>
-					<item key="recording_setup" level="0" text="Recording Setup" weight="10"><screen module="Recording" screen="RecordingSettings" /></item>
-					<item key="timeshift_setup" level="0" text="Timeshift Setup" weight="15"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
-					<item key="hdmirecord_setup" level="0" text="HDMI-IN Recording settings" weight="15" requires="HDMIin"><setup id="HDMIRecord"/></item>
-				</menu>
-				<menu key="harddisk" level="0" text="Harddisk" requires="Harddisk">
-					<item key="harddisk_setup" level="0"><setup id="harddisk"/></item>
-					<item key="harddisk_init" level="0" text="Initialization"><screen module="HarddiskSetup" screen="HarddiskSelection"/></item>
-					<item key="harddisk_check" level="0" text="Filesystem check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection"/></item>
-					<item key="flash_expander" level="2" text="Flash Expander" weight="40"><screen module="FlashExpander" screen="FlashExpander" /></item>
-				</menu>
-				<item key="network_setup" level="0" text="Network"><screen module="NetworkSetup" screen="NetworkAdapterSelection"/></item>
-				<item key="input_device_setup" level="1" text="Input devices"><screen module="InputDeviceSetup" screen="InputDeviceSelection"/></item>
-				<item key="keyboard_setup" text="Keyboard"><setup id="keyboard"/></item>
-				<item key="hotkey_setup" level="1" text="Hotkey"><screen module="Hotkey" screen="HotkeySetup"/></item>
+					<item key="accesslevel_setup" level="0" text="User Mode"><setup id="accesslevel"/></item>
+					<!-- Menu / Setup / Recordings, Playback & Timeshift -->
+					<menu key="rec" level="1" text="Playback, Recording &amp; Timeshift" weight="45">
+						<item key="playback_setup" level="0" text="Playback Setup" weight="5"><setup id="Playback" /></item>
+						<item key="recording_setup" level="0" text="Recording Setup" weight="10"><screen module="Recording" screen="RecordingSettings" /></item>
+						<item key="timeshift_setup" level="0" text="Timeshift Setup" weight="15"><screen module="Timeshift" screen="TimeshiftSettings" /></item>
+						<item key="hdmirecord_setup" level="0" text="HDMI-IN Recording settings" weight="15" requires="HDMIin"><setup id="HDMIRecord"/></item>
+					</menu>
+					<menu key="harddisk" level="0" text="Harddisk" requires="Harddisk">
+						<item key="harddisk_setup" level="0"><setup id="harddisk"/></item>
+						<item key="harddisk_init" level="0" text="Initialization"><screen module="HarddiskSetup" screen="HarddiskSelection"/></item>
+						<item key="harddisk_check" level="0" text="Filesystem check"><screen module="HarddiskSetup" screen="HarddiskFsckSelection"/></item>
+						<item key="flash_expander" level="2" text="Flash Expander" weight="40"><screen module="FlashExpander" screen="FlashExpander" /></item>
+					</menu>
+					<item key="network_setup" level="0" text="Network"><screen module="NetworkSetup" screen="NetworkAdapterSelection"/></item>
+					<item key="input_device_setup" level="1" text="Input devices"><screen module="InputDeviceSetup" screen="InputDeviceSelection"/></item>
+					<item key="keyboard_setup" text="Keyboard"><setup id="keyboard"/></item>
+					<item key="hotkey_setup" level="1" text="Hotkey"><screen module="Hotkey" screen="HotkeySetup"/></item>
 				</menu>
 			</menu>
 

--- a/data/setup.xml
+++ b/data/setup.xml
@@ -10,6 +10,7 @@
 		<item level="0" text="Show Main Menu as" description="Choose style of main menus" >config.usage.menutype</item>
 		<item level="1" text="Sort order for menu entries" description="This option allows you to hide and sort menu entries. When selecting user you can change order and hide menu items via the blue button. With the user defined hidden the blue button is not shown in the menus">config.usage.menu_sort_mode</item>
 		<item level="1" text="Sort order for setup entries" description="This option allows you to alphabetically sort setup menu entries.">config.usage.sort_settings</item>
+		<item level="1" text="Show setup default values" description="In Setup screens choose whether to show the default value of the selected item in the description field.">config.usage.setupShowDefault</item>
 		<item level="1" text="Show screen path" description="This option allows you to show the full screen path leading to the current screen.">config.usage.showScreenPath</item>
 		<item level="1" text="Sort Extension Menu" description="Select the sort order of the Extension Menu entries.">config.usage.sortExtensionslist</item>
 		<item level="1" text="Virtual keyboard skin" description="You can select the skin of virtual keyboard.">config.misc.virtualkeyBoardstyle</item>

--- a/doc/SETUP
+++ b/doc/SETUP
@@ -1,0 +1,411 @@
+Standardised and Uniform Setup Screens in Enigma2
+-------------------------------------------------
+
+Written by IanSav -  2-Apr-2018
+Updated by IanSav - 11-Jul-2020
+Updated by IanSav - 12-Sep-2020  (Thanks to Prl for suggestions.)
+Updated by IanSav -  3-Oct-2020
+
+
+INTRODUCTION:
+=============
+
+Enigma2 is a massive open source project that has many contributors and 
+add-ons.  Over time a number of alternative approaches to performing common 
+tasks have evolved.  This document documents some conventions that can be 
+adopted by all developers, contributors and skin authors to ensure that 
+everyone can work independently but still achieve results that work together 
+interchangeably.
+
+Standard variable names are documented, together with code and skin coding 
+conventions to assist in creating code that works more universally, with 
+additional benefits from improved Setup screen load performance and reduction 
+in merge issues between Enigma2 images.
+
+Lastly, the document explains the operation and features of the refactored 
+Setup screen interface ("Screen/Setup.py").
+
+
+REFACTOR OF "Screens/Setup.py":
+===============================
+
+The refactor of the "Screens/Setup.py" code has been based on various 
+features available in the main Enigma2 images.  That is, the code has been 
+written to make the "Screens/Setup.py" a superset of capabilities from all 
+the images.
+
+The changes, even with the enhancements, can result in a significant 
+reduction in time to generate any "Screens/Setup.py" based screen.  The 
+time taken to build any Setup screen is slightly longer for the first 
+screen item but then about 50 time faster for all subsequent searches.
+
+Significant changes, in no particular order, are:
+
+1)	All setup XML file data is cached into memory on the first access.  
+	Every subsequent access will check if the source file has been 
+	changed.  If so, the file will be reloaded and reprocessed.  If not, 
+	the cached results are returned.  This change can significantly 
+	improve "Screens/Setup.py" screen load times.
+
+	This change also means that the GUI no longer has to be restarted to 
+	allow changes to "setup.xml" to be processed by OpenPLi.
+
+2)	Optimise, improve and enhance generation of Setup screen item lists.  
+	This change allows the list to be processed once for display rather 
+	than the two or three cycles in some previous versions.
+
+3)	Create a log entry if the Setup screen has no valid entries.
+
+4)	Remove remnants of the setup.xml "separation" attribute directive.  
+	This feature is now offered via the skin parameter 
+	"ConfigListSeperator".
+
+5)	When enabled, always obey Setup screen sort setting.
+
+6)	If "%s %s" is found in an item's "text" or "description" attribute 
+	then replace it with the current box machine brand and model name.
+
+7)	Move the description code from the "SetupSummary" class into the main 
+	"Setup" class where it is used.
+
+8) 	For OpenPLi add footnote support.  If the last character of an entry 
+	item is an "*" then when this item is currently selected by the user 
+	a footnote message will appear to advise the user that a restart 
+	will be required if this item is changed.
+
+9)	Add an option to provide "Setup" screen graphic based on matching the 
+	setup "key" attribute with a graphic defined in a new "<setups>" 
+	element in the skin.  This code is conditional on having compatible 
+	changes in "skin.py".
+
+10)	Enable the HELP button to allow users to obtain help while using any 
+	"Screens/Setup.py" based screen.  To be fully operational these 
+	changes also need to be accompanied by appropriate changes to 
+	"Components/ConfigList.py".
+
+	To properly implement HELP and clean up the ActionMaps, the ActionMap 
+	and associated code should be removed from "Screens/Setup.py" and 
+	integrated into the ActionMap in "Components/ConfigList.py".
+
+11)	The "setup_key" skin facility appears to be unused.  The name has 
+	been changed to "Setupkey" to better match existing skin names.  
+	This option allows skin designers to create custom "Setup" based 
+	screens.
+
+	The "setup.xml" file's "setup" tag also offers a "skin" attribute to 
+	also allow for the screen for that setup key to be specified.
+
+	The order of screen selection is first look for a "skin" attribute 
+	screen, then try for a "Setupkey" screen and finally use the 
+	standard "Setup" screen.
+
+12)	Perform a PEP8 clean-up of the code.
+
+13)	Reorganise the imports and code blocks to improve readability of the 
+	refactored code.
+
+14)	Logic functionality has been added to the setup XML file.  The 
+	addition of "if", "elif" and "else" elements allow for "item" 
+	elements to be selected for inclusion or exclusion from any setup 
+	based screen.
+
+15)	The syntax consistency of the "if", "elif" and "item" elements is
+	now checked when the setup XML file is loaded.  Issues are reported 
+	in the log file.
+
+
+STRUCTURE OF "setup.xml" FILES:
+===============================
+
+Syntax:
+	
+	<setupxml>
+		<setup key="sample1" title="Sample1 settings">
+			<item level="0" text="Configuration item 1" description="This is the description text that explains the purpose and settings of config item 1.">configItem1</item>
+			<item level="0" text="Configuration item 2" description="This is the description text that explains the purpose and settings of config item 2.">configItem2</item>
+		</setup>
+		<setup key="sample2" title="Sample2 settings">
+			<item level="0" text="Configuration item 3" description="This is the description text that explains the purpose and settings of config item 3.">configItem3</item>
+			<item level="1" text="Configuration item 4" description="This is the description text that explains the purpose and settings of config item 4.">configItem4</item>
+			<if level="2">
+				<item text="Configuration item 5" description="This is the description text that explains the purpose and settings of config item 5.">configItem5</item>
+			<elif conditional="self.configVariable.value != 'once'" />
+				<item text="Configuration item 6" description="This is the description text that explains the purpose and settings of config item 6.">configItem6</item>
+			<else />
+				<item text="Configuration item 7" description="This is the description text that explains the purpose and settings of config item 7.">configItem7</item>
+			</if>
+		</setup>
+	</setupxml>
+
+The "setupxml" tag defines that the file is a setup configuration file. The 
+"setupxml" tag has no attributes and should contain a list of one or more 
+"setup" tag elements. Each of the "setup" tag elements should contain a list 
+of one or more "item" or "if" elements.  Each "item" tag element must contain 
+a configuration element that has been defined in "Components/UsageConfig.py" 
+or elsewhere.  Each "if" tag element should contain logic attributes "level", 
+"conditional" or "requires" to allow evaluation as to whether or not that 
+element's content will be used for the Setup screen.
+
+Each of the "setup" tags can have the following attributes:
+
+	Attribute	Required	Description
+	---------	--------	-----------
+	"key"		Mandatory	This attribute is the reference name, 
+					or key, used to identify this Setup 
+					screen.  By convention, common usage 
+					and agreement all keys should use 
+					lowercase names.
+
+	"title"		Mandatory	This attribute is the long form title 
+					text used for the heading or title of 
+					this setup screen.
+
+	"showOpenWebif"	Optional	This attribute is used to signal that 
+					this Setup screen should be made 
+					available in OpenWebif.
+
+	"requires"	Optional	This attribute is used to test is the 
+					nominated requirements have been met 
+					to enable the activation and use of 
+					this Setup screen.  The "requires" 
+					attribute value can be either the 
+					name of a config variable without 
+					the ".value" attribute, or the name 
+					of a SystemInfo entry.  If the first 
+					character of the attribute argument 
+					is "!" then the argument logic is 
+					inverted.
+
+	"skin"		Optional	This attribute is used to specify an 
+					override screen name defined in the 
+					skin to be used to display this Setup 
+					screen.
+
+Each of the "if" or "elif" tags can have at least one of the "level", 
+"conditional" or "requires" attributes as per the "item" tag as follows.
+
+Each of the "item" tags can have the following attributes:
+
+	Attribute	Required	Description
+	---------	--------	-----------
+	"text"		Mandatory	This attribute is the prompt text 
+					that is displayed to the user when 
+					activating this Setup screen.
+
+	"description"	Recommended	This attribute is the help prompt or 
+					information that can, and should, be 
+					used to offer guidance to users in 
+					when and how to set the associated 
+					configuration option.  If this is 
+					omitted no assistance or information 
+					will be offered to users.
+
+	"level"		Optional	The list of items that may be 
+					displayed in any Setup screen is 
+					dynamic. This attribute determines 
+					the user interface setup mode or 
+					level where this option may be 
+					displayed.  The default level, if 
+					not specified, is 0.
+
+				Level=0 -> Basic / Normal / Simple or higher
+				Level=1 -> Advanced / Intermediate or higher
+				Level=2 -> Expert
+				Level=9 -> Deactivate this entry
+
+	"conditional"	Optional	This attribute allows for programmed 
+					logic to decide is this item is 
+					eligible for display in the Setup 
+					screen.  The "conditional" attribute 
+					value is a Python expression that 
+					must evaluate to a value that can be 
+					converted to a Boolean.  It is 
+					evaluated in the context of a Setup 
+					class instance, and in the expression 
+					self refers to that instance (which 
+					is mainly useful for classes that 
+					derive from Setup, like 
+					MovieBrowserConfiguration).
+
+	"requires"	Optional	This attribute allows for "SystemInfo" 
+					or "config" variables to be used to 
+					enable display of the item.  If the 
+					first character of the attribute 
+					argument is "!" then the argument 
+					logic is inverted.
+
+	NOTE 1:	The text in the "text" and "description" attributes will 
+		be processed by the language translation system.
+
+	NOTE 2:	After the text in the "text" and "description" attributes 
+		has been translated any occurrence of the string "%s %s" will 
+		be replaced by the current make and model of the device upon 
+		which the code is running.
+
+	NOTE 3: If the last character of the "text" attribute is "*" then 
+		when this item is currently selected by the user a footnote 
+		message will appear to advise the user that a restart will be 
+		required if this item is changed.
+
+The payload or data element of the "item" tag should be the config element 
+defined in "Components/UsageConfig.py", or elsewhere, to be managed / changed 
+by the encompassing item tag.
+
+
+"Screens/Setup.py" / "Setup" SCREEN VARIABLES:
+==============================================
+
+	Variable		Description
+	--------		-----------
+	ScreenPath		This variable uses a source="ScreenPath" 
+				render=Label" widget that provides the menu 
+				path to the currently used "Setup" screen.
+
+	Title			This variable uses a source="title" 
+				render=Label" widget that provides the title 
+				of the "Setup" screen.
+
+	setupimage		This variable uses a name="setupimage" 
+				widget that provides a graphic image to 
+				represent the "Setup" screen being displayed.
+
+	config			This variable uses a name="config" widget 
+				that provides the list of available "Setup" 
+				configuration items.
+
+	description		This variable uses a name="description" 
+				widget that provides any available help or 
+				description text for the currently selected 
+				"Setup" item.
+
+	footnote		This variable uses a name="footnote" widget 
+				that provides a footnote message that 
+				typically advises when changing the item's 
+				value may trigger a restart.
+
+	key_red			This variable uses a source="key_red" 
+				render="Label" widget that provides the text 
+				for the RED button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.
+
+	key_green		This variable uses a source="key_green" 
+				render="Label" widget that provides the text 
+				for the GREEN button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.
+
+	key_yellow		This variable uses a source="key_yellow" 
+				render="Label" widget that provides the text 
+				for the YELLOW button.  This variable can 
+				also be used to trigger an associated button 
+				graphic.  The YELLOW button is not used by 
+				the core "Setup" class but may be used by 
+				other code based on the "Setup" class.
+
+	key_blue		This variable uses a source="key_blue" 
+				render="Label" widget that provides the text 
+				for the BLUE button.  This variable can also 
+				be used to trigger an associated button 
+				graphic.  The BLUE button is not used by 
+				the core "Setup" class but may be used by 
+				other code based on the "Setup" class.
+
+	key_menu		This variable uses a source="key_menu" 
+				render="Label" widget that provides a signal 
+				to the skin to display the MENU button.
+
+	key_help		This variable uses a source="key_help" 
+				render="Label" widget that provides a signal 
+				to the skin to display the HELP button.
+
+	VKeyIcon		This variable uses a source="VKeyIcon" 
+				render="Pixmap" widget that provides a signal 
+				to the skin to display the TEXT button when 
+				appropriate.
+
+	HelpWindow		This variable uses a name="HelpWindow" widget 
+				that displays the SMS helper window overlay 
+				when appropriate.
+
+
+SAMPLE "Setup" SCREEN:
+======================
+
+	<screen name="Setup" title="Setup" position="center,center" size="1000,565">
+		<widget source="ScreenPath" render="Label" position="560,0" size="440,15" conditional="ScreenPath" font="Regular;12" halign="right" transparent="1" />
+		<widget source="Title" render="Label" position="560,15" size="440,25" font="Regular;20" halign="right" noWrap="1" transparent="1" />
+		<widget source="key_red" render="Pixmap" pixmap="buttons/red.png" position="0,0" size="140,40" alphatest="blend" conditional="key_red">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_red" render="Label" position="0,0" size="140,40" backgroundColor="#9f1313" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_green" render="Pixmap" pixmap="buttons/green.png" position="140,0" size="140,40" alphatest="blend" conditional="key_green">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_green" render="Label" position="140,0" size="140,40" backgroundColor="#1f771f" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_yellow" render="Pixmap" pixmap="buttons/yellow.png" position="280,0" size="140,40" alphatest="blend" conditional="key_yellow">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_yellow" render="Label" position="280,0" size="140,40" backgroundColor="#a08500" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_blue" render="Pixmap" pixmap="buttons/blue.png" position="420,0" size="140,40" alphatest="blend" conditional="key_blue">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_blue" render="Label" position="420,0" size="140,40" backgroundColor="#141484" font="Regular;20" halign="center" transparent="1" valign="center" zPosition="+1" />
+		<widget source="key_menu" render="Pixmap" pixmap="buttons/key_menu.png" position="0,540" size="35,25" alphatest="blend" conditional="key_menu">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="key_help" render="Pixmap" pixmap="buttons/key_help.png" position="40,540" size="35,25" alphatest="blend" conditional="key_help">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget source="VKeyIcon" render="Pixmap" pixmap="buttons/key_text.png" position="80,540" size="35,25" alphatest="blend" transparent="1">
+			<convert type="ConditionalShowHide"/>
+		</widget>
+		<widget name="HelpWindow" pixmap="buttons/vkey_icon.png" position="0,250" size="1,1" zPosition="+1" />
+		<widget name="setupimage" position="0,50" size="200,400" alphatest="blend" conditional="setupimage" transparent="1" />
+		<widget name="config" position="200,50" size="800,400" enableWrapAround="1" scrollbarMode="showOnDemand" transparent="1" />
+		<widget name="footnote" position="200,460" size="800,20" font="Regular;18" transparent="1" valign="center" />
+		<widget name="description" position="200,490" size="800,75" font="Regular;20" transparent="1" valign="center" />
+	</screen>
+
+
+SKIN "Setups" SUPPORT ELEMENT:
+==============================
+
+Syntax:
+
+	<setups>
+		<setup key="default" image="setup_default.png" />
+		<setup key="sample1" image="setup_key.png" />
+	</setups>
+
+This element is optional but if defined allows a skin designer to associate 
+a graphical image with any "Screens/Setup.py" based screen.  The "setups" 
+tag element has no attributes and contains a list of "setup" tag elements.
+
+Each "setup" tag element must contain two attributes:
+
+	key	This attribute is the value of the key attribute from a 
+		setup.xml file.  If the keys match then this entry defines 
+		a graphical image that is to be used when the nominated 
+		Setup screen is displayed.
+
+	image	This attribute is the pathname of the graphical image that 
+		is to be associated with the Setup screen identified by the 
+		"key" attribute.
+
+There is a special "key" attribute with the name "default".  This entry, 
+if defined, assigns a default graphical image to be used in ALL 
+"Screens/Setup.py" screens that do not have a specifically assigned 
+image.
+
+
+CONCLUSION:
+===========
+
+For all the Enigma2 images there is a significant difference in facilities 
+offered by the "Screens/Setup.py code.  This proposal outlines what I 
+believe to be a conservative approach to making a significant and beneficial 
+change in unifying and standardising the operation of "Setup" screens across 
+the Enigma2 UI.
+
+---END---

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -1,24 +1,18 @@
 # -*- coding: utf-8 -*-
-from enigma import eListbox, eListboxPythonConfigContent, ePoint, eRCInput, eTimer
-from skin import parameters
-
-from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
-from Components.config import ConfigBoolean, ConfigElement, ConfigInteger, ConfigMacText, ConfigNothing, ConfigNumber, ConfigSelection, ConfigSequence, ConfigText, ACTIONKEY_0, ACTIONKEY_ASCII, ACTIONKEY_BACKSPACE, ACTIONKEY_DELETE, ACTIONKEY_ERASE, ACTIONKEY_FIRST, ACTIONKEY_LAST, ACTIONKEY_LEFT, ACTIONKEY_NUMBERS, ACTIONKEY_RIGHT, ACTIONKEY_SELECT, ACTIONKEY_TIMEOUT, ACTIONKEY_TOGGLE, configfile
-
 from Components.GUIComponent import GUIComponent
-from Components.Pixmap import Pixmap
-from Components.Sources.Boolean import Boolean
+from Components.config import KEY_LEFT, KEY_RIGHT, KEY_HOME, KEY_END, KEY_0, KEY_DELETE, KEY_BACKSPACE, KEY_OK, KEY_TOGGLEOW, KEY_ASCII, KEY_TIMEOUT, KEY_NUMBERS, ConfigElement, ConfigSelection, ConfigNothing
+from Components.ActionMap import NumberActionMap, ActionMap
 from Components.Sources.StaticText import StaticText
-from Screens.ChoiceBox import ChoiceBox
+from enigma import eListbox, eListboxPythonConfigContent, eRCInput, eTimer
 from Screens.MessageBox import MessageBox
-from Screens.Standby import QUIT_RESTART, TryQuitMainloop
-from Screens.VirtualKeyBoard import VirtualKeyBoard
+from Screens.ChoiceBox import ChoiceBox
+from skin import parameters
 
 
 class ConfigList(GUIComponent):
 	def __init__(self, list, session=None):
 		GUIComponent.__init__(self)
-		self.l = eListboxPythonConfigContent()  # noqa: E741
+		self.l = eListboxPythonConfigContent()
 		seperation = parameters.get("ConfigListSeperator", 200)
 		self.l.setSeperation(seperation)
 		height, space = parameters.get("ConfigListSlider", (17, 0))
@@ -37,23 +31,20 @@ class ConfigList(GUIComponent):
 	def execEnd(self):
 		rcinput = eRCInput.getInstance()
 		rcinput.setKeyboardMode(rcinput.kmNone)
-		self.timer.stop()
 		self.timer.callback.remove(self.timeout)
 
-	def timeout(self):
-		self.handleKey(ACTIONKEY_TIMEOUT)
-
-	def handleKey(self, key, callback=None):
-		selection = self.getCurrent()
-		if selection and len(selection) > 1 and selection[1].enabled:
-			selection[1].handleKey(key, callback)
-			self.invalidateCurrent()
-			if key in ACTIONKEY_NUMBERS:
-				self.timer.start(1000, 1)
-
 	def toggle(self):
-		self.getCurrent()[1].toggle()
+		selection = self.getCurrent()
+		selection[1].toggle()
 		self.invalidateCurrent()
+
+	def handleKey(self, key):
+		selection = self.getCurrent()
+		if selection and selection[1].enabled:
+			selection[1].handleKey(key)
+			self.invalidateCurrent()
+			if key in KEY_NUMBERS:
+				self.timer.start(1000, 1)
 
 	def getCurrent(self):
 		return self.l.getCurrentSelection()
@@ -73,22 +64,12 @@ class ConfigList(GUIComponent):
 		self.l.invalidateEntry(self.l.getCurrentSelectionIndex())
 
 	def invalidate(self, entry):
-		# When the entry to invalidate does not exist, just ignore the request.
-		# This eases up conditional setup screens a lot.
+		# when the entry to invalidate does not exist, just ignore the request.
+		# this eases up conditional setup screens a lot.
 		if entry in self.__list:
 			self.l.invalidateEntry(self.__list.index(entry))
 
 	GUI_WIDGET = eListbox
-
-	def isChanged(self):
-		for item in self.list:
-			if len(item) > 1 and item[1].isChanged():
-				return True
-		return False
-
-	def selectionEnabled(self, enabled):
-		if self.instance is not None:
-			self.instance.setSelectionEnable(enabled)
 
 	def selectionChanged(self):
 		if isinstance(self.current, tuple) and len(self.current) >= 2:
@@ -101,6 +82,14 @@ class ConfigList(GUIComponent):
 		for x in self.onSelectionChanged:
 			x()
 
+	def hideHelp(self):
+		if isinstance(self.current, tuple) and len(self.current) >= 2:
+			self.current[1].hideHelp(self.session)
+
+	def showHelp(self):
+		if isinstance(self.current, tuple) and len(self.current) >= 2:
+			self.current[1].showHelp(self.session)
+
 	def postWidgetCreate(self, instance):
 		instance.selectionChanged.get().append(self.selectionChanged)
 		instance.setContent(self.l)
@@ -112,135 +101,95 @@ class ConfigList(GUIComponent):
 		instance.selectionChanged.get().remove(self.selectionChanged)
 		instance.setContent(None)
 
-	def setList(self, configList):
-		self.__list = configList
+	def setList(self, l):
+		self.timer.stop()
+		self.__list = l
 		self.l.setList(self.__list)
-		if configList is not None:
-			for x in configList:
-				assert len(x) < 2 or isinstance(x[1], ConfigElement), "[ConfigList] Error: Entry in ConfigList '%s' must be a ConfigElement!" % str(x[1])
+
+		if l is not None:
+			for x in l:
+				assert len(x) < 2 or isinstance(x[1], ConfigElement), "entry in ConfigList " + str(x[1]) + " must be a ConfigElement"
 
 	def getList(self):
 		return self.__list
 
 	list = property(getList, setList)
 
-	def moveTop(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveTop)
+	def timeout(self):
+		self.handleKey(KEY_TIMEOUT)
+
+	def isChanged(self):
+		is_changed = False
+		for x in self.list:
+			is_changed |= x[1].isChanged()
+
+		return is_changed
+
+	def getNotifierNeeded(self):
+		current = self.getCurrent()
+		return  current and current[1].getNotifierNeeded()
 
 	def pageUp(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageUp)
 
-	def moveUp(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveUp)
-
-	def moveDown(self):
-		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveDown)
-
 	def pageDown(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageDown)
 
-	def moveBottom(self):
+	def selectionEnabled(self, enabled):
 		if self.instance is not None:
-			self.instance.moveSelection(self.instance.moveEnd)
+			self.instance.setSelectionEnable(enabled)
 
 
 class ConfigListScreen:
-	def __init__(self, list, session=None, on_change=None, fullUI=False):
-		self.entryChanged = on_change if on_change is not None else lambda: None
-		if fullUI:
-			if "key_red" not in self:
-				self["key_red"] = StaticText(_("Cancel"))
-			if "key_green" not in self:
-				self["key_green"] = StaticText(_("Save"))
-			self["fullUIActions"] = HelpableActionMap(self, ["ConfigListActions"], {
-				"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
-				"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
-				"save": (self.keySave, _("Save all changed settings and exit"))
-			}, prio=1, description=_("Common Setup Actions"))
-		if "key_menu" not in self:
-			self["key_menu"] = StaticText(_("MENU"))
-		if "HelpWindow" not in self:
-			self["HelpWindow"] = Pixmap()
-			self["HelpWindow"].hide()
-		if "VKeyIcon" not in self:
-			self["VKeyIcon"] = Boolean(False)
-		self["configActions"] = HelpableActionMap(self, ["ConfigListActions"], {
-			"select": (self.keySelect, _("Select, toggle, process or edit the current entry"))
-		}, prio=1, description=_("Common Setup Actions"))
-		self["navigationActions"] = HelpableActionMap(self, ["NavigationActions"], {
-			"top": (self.keyTop, _("Move to first line / screen")),
-			"pageUp": (self.keyPageUp, _("Move up a screen")),
-			"up": (self.keyUp, _("Move up a line")),
-			"first": (self.keyFirst, _("Jump to first item in list or the start of text")),
-			"left": (self.keyLeft, _("Select the previous item in list or move cursor left")),
-			"right": (self.keyRight, _("Select the next item in list or move cursor right")),
-			"last": (self.keyLast, _("Jump to last item in list or the end of text")),
-			"down": (self.keyDown, _("Move down a line")),
-			"pageDown": (self.keyPageDown, _("Move down a screen")),
-			"bottom": (self.keyBottom, _("Move to last line / screen"))
-		}, prio=1, description=_("Common Setup Actions"))
-		self["menuConfigActions"] = HelpableActionMap(self, "ConfigListActions", {
-			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
-		}, prio=1, description=_("Common Setup Actions"))
-		self["menuConfigActions"].setEnabled(False if fullUI else True)
-		self["editConfigActions"] = HelpableNumberActionMap(self, ["NumberActions", "TextEditActions"], {
-			"backspace": (self.keyBackspace, _("Delete character to left of cursor or select AM times")),
-			"delete": (self.keyDelete, _("Delete character under cursor or select PM times")),
-			"erase": (self.keyErase, _("Delete all the text")),
-			"toggleOverwrite": (self.keyToggle, _("Toggle new text inserts before or overwrites existing text")),
-			"1": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"2": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"3": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"4": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"5": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"6": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"7": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"8": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"9": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"0": (self.keyNumberGlobal, _("Number or SMS style data entry")),
-			"gotAsciiCode": (self.keyGotAscii, _("Keyboard data entry"))
-		}, prio=1, description=_("Common Setup Actions"))
-		self["editConfigActions"].setEnabled(False if fullUI else True)
-		self["virtualKeyBoardActions"] = HelpableActionMap(self, "VirtualKeyboardActions", {
-			"showVirtualKeyboard": (self.keyText, _("Display the virtual keyboard for data entry"))
-		}, prio=1, description=_("Common Setup Actions"))
-		self["virtualKeyBoardActions"].setEnabled(False)
+	def __init__(self, list, session=None, on_change=None):
+		self["config_actions"] = NumberActionMap(["SetupActions", "InputAsciiActions", "KeyboardInputActions"], {
+			"gotAsciiCode": self.keyGotAscii,
+			"ok": self.keyOK,
+			"left": self.keyLeft,
+			"right": self.keyRight,
+			"home": self.keyHome,
+			"end": self.keyEnd,
+			"deleteForward": self.keyDelete,
+			"deleteBackward": self.keyBackspace,
+			"toggleOverwrite": self.keyToggleOW,
+			"pageUp": self.keyPageUp,
+			"pageDown": self.keyPageDown,
+			"1": self.keyNumberGlobal,
+			"2": self.keyNumberGlobal,
+			"3": self.keyNumberGlobal,
+			"4": self.keyNumberGlobal,
+			"5": self.keyNumberGlobal,
+			"6": self.keyNumberGlobal,
+			"7": self.keyNumberGlobal,
+			"8": self.keyNumberGlobal,
+			"9": self.keyNumberGlobal,
+			"0": self.keyNumberGlobal,
+			"file": self.keyFile
+		}, -1)  # to prevent left/right overriding the listbox
 
-		# Temporary support for legacy code and plugins that hasn't yet been updated (next 4 lines).
-		self["config_actions"] = DummyActions()
-		self["config_actions"].setEnabled = self.dummyConfigActions
-		self["VirtualKB"] = DummyActions()
-		self["VirtualKB"].setEnabled = self.dummyVKBActions
+		self.onChangedEntry = []
+		self.onSave = []
+
+		self["VirtualKB"] = ActionMap(["VirtualKeyboardActions"], {
+			"showVirtualKeyboard": self.KeyText,
+		}, -2)
+		self["VirtualKB"].setEnabled(False)
 
 		self["config"] = ConfigList(list, session=session)
 
-		self.setCancelMessage(None)
-		self.setRestartMessage(None)
-		self.onChangedEntry = []
-		self.onSave = []
-		self.manipulatedItems = []  # keep track of all manipulated items including ones that have been removed from self["config"].list (currently used by Setup.py)
-		if self.noNativeKeys not in self.onLayoutFinish:
-			self.onLayoutFinish.append(self.noNativeKeys)
+		if "key_pvr" not in self:
+			self["key_pvr"] = StaticText(_("PVR"))
+
+		self.on_change = on_change
+
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
-		if self.showHelpWindow not in self.onExecBegin:
-			self.onExecBegin.append(self.showHelpWindow)
-		if self.hideHelpWindow not in self.onExecEnd:
-			self.onExecEnd.append(self.hideHelpWindow)
 
-	def setCancelMessage(self, msg):
-		self.cancelMsg = _("Really close without saving settings?") if msg is None else msg
-
-	def setRestartMessage(self, msg):
-		self.restartMsg = _("Restart GUI now?") if msg is None else msg
-
-	def getCurrentItem(self):
-		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 1 and self["config"].getCurrent()[1] or None
+	def createSummary(self):
+		from Screens.Setup import SetupSummary
+		return SetupSummary
 
 	def getCurrentItem(self):
 		return self["config"].getCurrent() and self["config"].getCurrent()[1] or None
@@ -263,157 +212,104 @@ class ConfigListScreen:
 
 	def handleInputHelpers(self):
 		currConfig = self["config"].getCurrent()
-		if currConfig is not None:
-			if isinstance(currConfig[1], (ConfigInteger, ConfigMacText, ConfigSequence, ConfigText)):
-				self["editConfigActions"].setEnabled(True)
-			else:
-				self["editConfigActions"].setEnabled(False)
-			if isinstance(currConfig[1], ConfigSelection) and not isinstance(currConfig[1], ConfigNothing):
-				self["menuConfigActions"].setEnabled(True)
-				self["key_menu"].setText(_("MENU"))
-			else:
-				self["menuConfigActions"].setEnabled(False)
-				self["key_menu"].setText("")
-			if isinstance(currConfig[1], (ConfigText, ConfigMacText)) and "HelpWindow" in self and currConfig[1].help_window and currConfig[1].help_window.instance is not None:
+		if currConfig is not None and currConfig[1].__class__.__name__ in ('ConfigText', 'ConfigPassword'):
+			if "VKeyIcon" in self:
+				self["VirtualKB"].setEnabled(True)
+				self["VKeyIcon"].boolean = True
+			if "HelpWindow" in self and currConfig[1].help_window and currConfig[1].help_window.instance is not None:
 				helpwindowpos = self["HelpWindow"].getPosition()
+				from enigma import ePoint
 				currConfig[1].help_window.instance.move(ePoint(helpwindowpos[0], helpwindowpos[1]))
-			if isinstance(currConfig[1], ConfigText):
-				self.showVirtualKeyBoard(True)
-			else:
-				self.showVirtualKeyBoard(False)
-			if "description" in self:
-				self["description"].text = self.getCurrentDescription()
-
-	def showVirtualKeyBoard(self, state):
-		if "VKeyIcon" in self:
-			self["VKeyIcon"].boolean = state
-			self["virtualKeyBoardActions"].setEnabled(state)
-
-	def showHelpWindow(self):
-		self.displayHelp(True)
-
-	def hideHelpWindow(self):
-		self.displayHelp(False)
-
-	def displayHelp(self, state):
-		if "config" in self and "HelpWindow" in self and self["config"].getCurrent() is not None and len(self["config"].getCurrent()) > 1:
-			currConf = self["config"].getCurrent()[1]
-			if isinstance(currConf, (ConfigText, ConfigMacText)) and currConf.help_window is not None and currConf.help_window.instance is not None:
-				if state:
-					currConf.help_window.show()
-				else:
-					currConf.help_window.hide()
-
-	def keySelect(self):
-		if isinstance(self.getCurrentItem(), ConfigBoolean):
-			self.keyToggle()
-		elif isinstance(self.getCurrentItem(), ConfigSelection):
-			self.keyMenu()
-		elif isinstance(self.getCurrentItem(), ConfigText) and not isinstance(self.getCurrentItem(), ConfigNumber):
-			self.keyText()
+		elif "VKeyIcon" in self:
+			self["VirtualKB"].setEnabled(False)
+			self["VKeyIcon"].boolean = False
+		if currConfig is not None and isinstance(currConfig[1], ConfigSelection) and not isinstance(currConfig[1], ConfigNothing):
+			self["key_pvr"].setText(_("PVR"))
 		else:
-			self["config"].handleKey(ACTIONKEY_SELECT, self.entryChanged)
+			self["key_pvr"].setText("")
+		if "description" in self:
+			self["description"].text = self.getCurrentDescription()
 
-	def keyOK(self):  # This is the deprecated version of keySelect!
-		self.keySelect()
+	def KeyText(self):
+		self["config"].hideHelp()
+		from Screens.VirtualKeyBoard import VirtualKeyBoard
+		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title=self["config"].getCurrent()[0], text=self["config"].getCurrent()[1].getValue())
 
-	def keyText(self):
-		self.session.openWithCallback(self.keyTextCallback, VirtualKeyBoard, title=self.getCurrentEntry(), text=str(self.getCurrentValue()))
-
-	def keyTextCallback(self, callback=None):
+	def VirtualKeyBoardCallback(self, callback=None):
 		if callback is not None:
-			prev = str(self.getCurrentValue())
 			self["config"].getCurrent()[1].setValue(callback)
-			self["config"].invalidateCurrent()
-			if callback != prev:
-				self.entryChanged()
+			self["config"].invalidate(self["config"].getCurrent())
+			self.__changed()
+		self["config"].showHelp()
 
-	def keyMenu(self):
-		currConfig = self["config"].getCurrent()
-		if currConfig and currConfig[1].enabled and hasattr(currConfig[1], "description"):
-			self.session.openWithCallback(
-				self.keyMenuCallback, ChoiceBox, title=currConfig[0],
-				list=list(zip(currConfig[1].description, currConfig[1].choices)),
-				selection=currConfig[1].getIndex(),
-				keys=[]
-			)
-
-	def keyMenuCallback(self, answer):
-		if answer:
-			self["config"].getCurrent()[1].value = answer[1]
-			self["config"].invalidateCurrent()
-			self.entryChanged()
-
-	def keyTop(self):
-		self["config"].moveTop()
-
-	def keyPageUp(self):
-		self["config"].pageUp()
-
-	def keyUp(self):
-		self["config"].moveUp()
-
-	def keyFirst(self):
-		self["config"].handleKey(ACTIONKEY_FIRST, self.entryChanged)
+	def keyOK(self):
+		self["config"].handleKey(KEY_OK)
 
 	def keyLeft(self):
-		self["config"].handleKey(ACTIONKEY_LEFT, self.entryChanged)
+		self["config"].handleKey(KEY_LEFT)
+		self.changed()
 
 	def keyRight(self):
-		self["config"].handleKey(ACTIONKEY_RIGHT, self.entryChanged)
+		self["config"].handleKey(KEY_RIGHT)
+		self.changed()
 
-	def keyLast(self):
-		self["config"].handleKey(ACTIONKEY_LAST, self.entryChanged)
+	def keyHome(self):
+		self["config"].handleKey(KEY_HOME)
+		self.changed()
 
-	def keyDown(self):
-		self["config"].moveDown()
+	def keyEnd(self):
+		self["config"].handleKey(KEY_END)
+		self.changed()
+
+	def keyDelete(self):
+		self["config"].handleKey(KEY_DELETE)
+		self.changed()
+
+	def keyBackspace(self):
+		self["config"].handleKey(KEY_BACKSPACE)
+		self.changed()
+
+	def keyToggleOW(self):
+		self["config"].handleKey(KEY_TOGGLEOW)
+		self.changed()
+
+	def keyGotAscii(self):
+		self["config"].handleKey(KEY_ASCII)
+		self.changed()
+
+	def keyNumberGlobal(self, number):
+		self["config"].handleKey(KEY_0 + number)
+		self.changed()
 
 	def keyPageDown(self):
 		self["config"].pageDown()
 
-	def keyBottom(self):
-		self["config"].moveBottom()
+	def keyPageUp(self):
+		self["config"].pageUp()
 
-	def keyBackspace(self):
-		self["config"].handleKey(ACTIONKEY_BACKSPACE, self.entryChanged)
+	def changed(self):
+		if self.on_change and self["config"].getNotifierNeeded():
+			self.on_change()
 
-	def keyDelete(self):
-		self["config"].handleKey(ACTIONKEY_DELETE, self.entryChanged)
+	def keyFile(self):
+		selection = self["config"].getCurrent()
+		if selection and selection[1].enabled and hasattr(selection[1], "description"):
+			self.session.openWithCallback(
+				self.handleKeyFileCallback, ChoiceBox, selection[0],
+				list=list(zip(selection[1].description, selection[1].choices)),
+				selection=selection[1].choices.index(selection[1].value),
+				keys=[]
+			)
 
-	def keyErase(self):
-		self["config"].handleKey(ACTIONKEY_ERASE, self.entryChanged)
-
-	def keyToggle(self):
-		self["config"].handleKey(ACTIONKEY_TOGGLE, self.entryChanged)
-
-	def keyGotAscii(self):
-		self["config"].handleKey(ACTIONKEY_ASCII, self.entryChanged)
-
-	def keyNumberGlobal(self, number):
-		self["config"].handleKey(ACTIONKEY_0 + number, self.entryChanged)
-
-	def keySave(self):
-		for notifier in self.onSave:
-			notifier()
-		if self.saveAll():
-			self.session.openWithCallback(self.restartConfirm, MessageBox, self.restartMsg, default=True, type=MessageBox.TYPE_YESNO)
-		else:
-			self.close()
-
-	def restartConfirm(self, result):
-		if result:
-			self.session.open(TryQuitMainloop, retvalue=QUIT_RESTART)
-			self.close()
+	def handleKeyFileCallback(self, answer):
+		if answer:
+			self["config"].getCurrent()[1].value = answer[1]
+			self["config"].invalidateCurrent()
+			self.changed()
 
 	def saveAll(self):
-		restart = False
-		for item in set(self["config"].list + self.manipulatedItems):
-			if len(item) > 1:
-				if item[0].endswith("*") and item[1].isChanged():
-					restart = True
-				item[1].save()
-		configfile.save()
-		return restart
+		for x in self["config"].list:
+			x[1].save()
 
 	def addSaveNotifier(self, notifier):
 		if callable(notifier):
@@ -421,69 +317,30 @@ class ConfigListScreen:
 		else:
 			raise TypeError("[ConfigList] Error: Notifier must be callable!")
 
-	def removeSaveNotifier(self, notifier):
-		while notifier in self.onSave:
-			self.onSave.remove(notifier)
-
-	def clearSaveNotifiers(self):
-		self.onSave = []
-
-	def keyCancel(self):
-		self.closeConfigList(())
-
-	def addSaveNotifier(self, notifier):
-		if callable(notifier):
-			self.onSave.append(notifier)
-		else:
-			raise TypeError("[ConfigList] Error: Notifier must be callable!")
-
-	def closeRecursive(self):
-		self.closeConfigList((True,))
-
-	def closeConfigList(self, closeParameters=()):
-		if self["config"].isChanged() or self.manipulatedItems:
-			self.closeParameters = closeParameters
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, self.cancelMsg, default=False, type=MessageBox.TYPE_YESNO)
-		else:
-			self.close(*closeParameters)
+	# keySave and keyCancel are just provided in case you need them.
+	# you have to call them by yourself.
+	def keySave(self):
+		self.saveAll()
+		self.close()
 
 	def cancelConfirm(self, result):
 		if not result:
+			self["config"].showHelp()
 			return
-		for item in set(self["config"].list + self.manipulatedItems):
-			if len(item) > 1:
-				item[1].cancel()
-		if not hasattr(self, "closeParameters"):
-			self.closeParameters = ()
-		self.close(*self.closeParameters)
 
-	def createSummary(self):  # This should not be required if ConfigList is invoked via Setup (as it should).
-		from Screens.Setup import SetupSummary
-		return SetupSummary
+		for x in self["config"].list:
+			x[1].cancel()
+		self.close()
 
-	def run(self):  # Allow ConfigList based screens to be processed from the Wizard.
-		self.keySave()
+	def closeMenuList(self, recursive=False):
+		if self["config"].isChanged():
+			self["config"].hideHelp()
+			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"))
+		else:
+			self.close(recursive)
 
-	def dummyConfigActions(self, value):  # Temporary support for legacy code and plugins that hasn't yet been updated.
-		self["configActions"].setEnabled(value)
-		self["navigationActions"].setEnabled(value)
-		self["menuConfigActions"].setEnabled(value)
-		self["charConfigActions"].setEnabled(value)
-		self["editConfigActions"].setEnabled(value)
+	def keyCancel(self):
+		self.closeMenuList()
 
-	def dummyVKBActions(self, value):  # Temporary support for legacy code and plugins that hasn't yet been updated.
-		self["virtualKeyBoardActions"].setEnabled(value)
-
-
-class DummyActions:  # Temporary support for legacy code and plugins that hasn't yet been updated.
-	def setEnabled(self, enabled):
-		pass
-
-	def destroy(self):
-		pass
-
-	def execBegin(self):
-		pass
-
-	def execEnd(self):
-		pass
+	def closeRecursive(self):
+		self.closeMenuList(True)

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from enigma import eListbox, eListboxPythonConfigContent, ePoint, eRCInput, eTimer
-from skin import parameters, applySkinFactor
+from skin import parameters
 
 from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
 from Components.config import ConfigBoolean, ConfigElement, ConfigInteger, ConfigMacText, ConfigNothing, ConfigNumber, ConfigSelection, ConfigSequence, ConfigText, ACTIONKEY_0, ACTIONKEY_ASCII, ACTIONKEY_BACKSPACE, ACTIONKEY_DELETE, ACTIONKEY_ERASE, ACTIONKEY_FIRST, ACTIONKEY_LAST, ACTIONKEY_LEFT, ACTIONKEY_NUMBERS, ACTIONKEY_RIGHT, ACTIONKEY_SELECT, ACTIONKEY_TIMEOUT, ACTIONKEY_TOGGLE, configfile

--- a/lib/python/Components/ConfigList.py
+++ b/lib/python/Components/ConfigList.py
@@ -1,18 +1,24 @@
 # -*- coding: utf-8 -*-
+from enigma import eListbox, eListboxPythonConfigContent, ePoint, eRCInput, eTimer
+from skin import parameters, applySkinFactor
+
+from Components.ActionMap import HelpableActionMap, HelpableNumberActionMap
+from Components.config import ConfigBoolean, ConfigElement, ConfigInteger, ConfigMacText, ConfigNothing, ConfigNumber, ConfigSelection, ConfigSequence, ConfigText, ACTIONKEY_0, ACTIONKEY_ASCII, ACTIONKEY_BACKSPACE, ACTIONKEY_DELETE, ACTIONKEY_ERASE, ACTIONKEY_FIRST, ACTIONKEY_LAST, ACTIONKEY_LEFT, ACTIONKEY_NUMBERS, ACTIONKEY_RIGHT, ACTIONKEY_SELECT, ACTIONKEY_TIMEOUT, ACTIONKEY_TOGGLE, configfile
+
 from Components.GUIComponent import GUIComponent
-from Components.config import KEY_LEFT, KEY_RIGHT, KEY_HOME, KEY_END, KEY_0, KEY_DELETE, KEY_BACKSPACE, KEY_OK, KEY_TOGGLEOW, KEY_ASCII, KEY_TIMEOUT, KEY_NUMBERS, ConfigElement, ConfigSelection, ConfigNothing
-from Components.ActionMap import NumberActionMap, ActionMap
+from Components.Pixmap import Pixmap
+from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
-from enigma import eListbox, eListboxPythonConfigContent, eRCInput, eTimer
-from Screens.MessageBox import MessageBox
 from Screens.ChoiceBox import ChoiceBox
-from skin import parameters
+from Screens.MessageBox import MessageBox
+from Screens.Standby import QUIT_RESTART, TryQuitMainloop
+from Screens.VirtualKeyBoard import VirtualKeyBoard
 
 
 class ConfigList(GUIComponent):
 	def __init__(self, list, session=None):
 		GUIComponent.__init__(self)
-		self.l = eListboxPythonConfigContent()
+		self.l = eListboxPythonConfigContent()  # noqa: E741
 		seperation = parameters.get("ConfigListSeperator", 200)
 		self.l.setSeperation(seperation)
 		height, space = parameters.get("ConfigListSlider", (17, 0))
@@ -31,20 +37,23 @@ class ConfigList(GUIComponent):
 	def execEnd(self):
 		rcinput = eRCInput.getInstance()
 		rcinput.setKeyboardMode(rcinput.kmNone)
+		self.timer.stop()
 		self.timer.callback.remove(self.timeout)
 
-	def toggle(self):
-		selection = self.getCurrent()
-		selection[1].toggle()
-		self.invalidateCurrent()
+	def timeout(self):
+		self.handleKey(ACTIONKEY_TIMEOUT)
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		selection = self.getCurrent()
-		if selection and selection[1].enabled:
-			selection[1].handleKey(key)
+		if selection and len(selection) > 1 and selection[1].enabled:
+			selection[1].handleKey(key, callback)
 			self.invalidateCurrent()
-			if key in KEY_NUMBERS:
+			if key in ACTIONKEY_NUMBERS:
 				self.timer.start(1000, 1)
+
+	def toggle(self):
+		self.getCurrent()[1].toggle()
+		self.invalidateCurrent()
 
 	def getCurrent(self):
 		return self.l.getCurrentSelection()
@@ -64,12 +73,22 @@ class ConfigList(GUIComponent):
 		self.l.invalidateEntry(self.l.getCurrentSelectionIndex())
 
 	def invalidate(self, entry):
-		# when the entry to invalidate does not exist, just ignore the request.
-		# this eases up conditional setup screens a lot.
+		# When the entry to invalidate does not exist, just ignore the request.
+		# This eases up conditional setup screens a lot.
 		if entry in self.__list:
 			self.l.invalidateEntry(self.__list.index(entry))
 
 	GUI_WIDGET = eListbox
+
+	def isChanged(self):
+		for item in self.list:
+			if len(item) > 1 and item[1].isChanged():
+				return True
+		return False
+
+	def selectionEnabled(self, enabled):
+		if self.instance is not None:
+			self.instance.setSelectionEnable(enabled)
 
 	def selectionChanged(self):
 		if isinstance(self.current, tuple) and len(self.current) >= 2:
@@ -82,14 +101,6 @@ class ConfigList(GUIComponent):
 		for x in self.onSelectionChanged:
 			x()
 
-	def hideHelp(self):
-		if isinstance(self.current, tuple) and len(self.current) >= 2:
-			self.current[1].hideHelp(self.session)
-
-	def showHelp(self):
-		if isinstance(self.current, tuple) and len(self.current) >= 2:
-			self.current[1].showHelp(self.session)
-
 	def postWidgetCreate(self, instance):
 		instance.selectionChanged.get().append(self.selectionChanged)
 		instance.setContent(self.l)
@@ -101,95 +112,135 @@ class ConfigList(GUIComponent):
 		instance.selectionChanged.get().remove(self.selectionChanged)
 		instance.setContent(None)
 
-	def setList(self, l):
-		self.timer.stop()
-		self.__list = l
+	def setList(self, configList):
+		self.__list = configList
 		self.l.setList(self.__list)
-
-		if l is not None:
-			for x in l:
-				assert len(x) < 2 or isinstance(x[1], ConfigElement), "entry in ConfigList " + str(x[1]) + " must be a ConfigElement"
+		if configList is not None:
+			for x in configList:
+				assert len(x) < 2 or isinstance(x[1], ConfigElement), "[ConfigList] Error: Entry in ConfigList '%s' must be a ConfigElement!" % str(x[1])
 
 	def getList(self):
 		return self.__list
 
 	list = property(getList, setList)
 
-	def timeout(self):
-		self.handleKey(KEY_TIMEOUT)
-
-	def isChanged(self):
-		is_changed = False
-		for x in self.list:
-			is_changed |= x[1].isChanged()
-
-		return is_changed
-
-	def getNotifierNeeded(self):
-		current = self.getCurrent()
-		return  current and current[1].getNotifierNeeded()
+	def moveTop(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveTop)
 
 	def pageUp(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageUp)
 
+	def moveUp(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveUp)
+
+	def moveDown(self):
+		if self.instance is not None:
+			self.instance.moveSelection(self.instance.moveDown)
+
 	def pageDown(self):
 		if self.instance is not None:
 			self.instance.moveSelection(self.instance.pageDown)
 
-	def selectionEnabled(self, enabled):
+	def moveBottom(self):
 		if self.instance is not None:
-			self.instance.setSelectionEnable(enabled)
+			self.instance.moveSelection(self.instance.moveEnd)
 
 
 class ConfigListScreen:
-	def __init__(self, list, session=None, on_change=None):
-		self["config_actions"] = NumberActionMap(["SetupActions", "InputAsciiActions", "KeyboardInputActions"], {
-			"gotAsciiCode": self.keyGotAscii,
-			"ok": self.keyOK,
-			"left": self.keyLeft,
-			"right": self.keyRight,
-			"home": self.keyHome,
-			"end": self.keyEnd,
-			"deleteForward": self.keyDelete,
-			"deleteBackward": self.keyBackspace,
-			"toggleOverwrite": self.keyToggleOW,
-			"pageUp": self.keyPageUp,
-			"pageDown": self.keyPageDown,
-			"1": self.keyNumberGlobal,
-			"2": self.keyNumberGlobal,
-			"3": self.keyNumberGlobal,
-			"4": self.keyNumberGlobal,
-			"5": self.keyNumberGlobal,
-			"6": self.keyNumberGlobal,
-			"7": self.keyNumberGlobal,
-			"8": self.keyNumberGlobal,
-			"9": self.keyNumberGlobal,
-			"0": self.keyNumberGlobal,
-			"file": self.keyFile
-		}, -1)  # to prevent left/right overriding the listbox
+	def __init__(self, list, session=None, on_change=None, fullUI=False):
+		self.entryChanged = on_change if on_change is not None else lambda: None
+		if fullUI:
+			if "key_red" not in self:
+				self["key_red"] = StaticText(_("Cancel"))
+			if "key_green" not in self:
+				self["key_green"] = StaticText(_("Save"))
+			self["fullUIActions"] = HelpableActionMap(self, ["ConfigListActions"], {
+				"cancel": (self.keyCancel, _("Cancel any changed settings and exit")),
+				"close": (self.closeRecursive, _("Cancel any changed settings and exit all menus")),
+				"save": (self.keySave, _("Save all changed settings and exit"))
+			}, prio=1, description=_("Common Setup Actions"))
+		if "key_menu" not in self:
+			self["key_menu"] = StaticText(_("MENU"))
+		if "HelpWindow" not in self:
+			self["HelpWindow"] = Pixmap()
+			self["HelpWindow"].hide()
+		if "VKeyIcon" not in self:
+			self["VKeyIcon"] = Boolean(False)
+		self["configActions"] = HelpableActionMap(self, ["ConfigListActions"], {
+			"select": (self.keySelect, _("Select, toggle, process or edit the current entry"))
+		}, prio=1, description=_("Common Setup Actions"))
+		self["navigationActions"] = HelpableActionMap(self, ["NavigationActions"], {
+			"top": (self.keyTop, _("Move to first line / screen")),
+			"pageUp": (self.keyPageUp, _("Move up a screen")),
+			"up": (self.keyUp, _("Move up a line")),
+			"first": (self.keyFirst, _("Jump to first item in list or the start of text")),
+			"left": (self.keyLeft, _("Select the previous item in list or move cursor left")),
+			"right": (self.keyRight, _("Select the next item in list or move cursor right")),
+			"last": (self.keyLast, _("Jump to last item in list or the end of text")),
+			"down": (self.keyDown, _("Move down a line")),
+			"pageDown": (self.keyPageDown, _("Move down a screen")),
+			"bottom": (self.keyBottom, _("Move to last line / screen"))
+		}, prio=1, description=_("Common Setup Actions"))
+		self["menuConfigActions"] = HelpableActionMap(self, "ConfigListActions", {
+			"menu": (self.keyMenu, _("Display selection list as a selection menu")),
+		}, prio=1, description=_("Common Setup Actions"))
+		self["menuConfigActions"].setEnabled(False if fullUI else True)
+		self["editConfigActions"] = HelpableNumberActionMap(self, ["NumberActions", "TextEditActions"], {
+			"backspace": (self.keyBackspace, _("Delete character to left of cursor or select AM times")),
+			"delete": (self.keyDelete, _("Delete character under cursor or select PM times")),
+			"erase": (self.keyErase, _("Delete all the text")),
+			"toggleOverwrite": (self.keyToggle, _("Toggle new text inserts before or overwrites existing text")),
+			"1": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"2": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"3": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"4": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"5": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"6": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"7": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"8": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"9": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"0": (self.keyNumberGlobal, _("Number or SMS style data entry")),
+			"gotAsciiCode": (self.keyGotAscii, _("Keyboard data entry"))
+		}, prio=1, description=_("Common Setup Actions"))
+		self["editConfigActions"].setEnabled(False if fullUI else True)
+		self["virtualKeyBoardActions"] = HelpableActionMap(self, "VirtualKeyboardActions", {
+			"showVirtualKeyboard": (self.keyText, _("Display the virtual keyboard for data entry"))
+		}, prio=1, description=_("Common Setup Actions"))
+		self["virtualKeyBoardActions"].setEnabled(False)
 
-		self.onChangedEntry = []
-		self.onSave = []
-
-		self["VirtualKB"] = ActionMap(["VirtualKeyboardActions"], {
-			"showVirtualKeyboard": self.KeyText,
-		}, -2)
-		self["VirtualKB"].setEnabled(False)
+		# Temporary support for legacy code and plugins that hasn't yet been updated (next 4 lines).
+		self["config_actions"] = DummyActions()
+		self["config_actions"].setEnabled = self.dummyConfigActions
+		self["VirtualKB"] = DummyActions()
+		self["VirtualKB"].setEnabled = self.dummyVKBActions
 
 		self["config"] = ConfigList(list, session=session)
 
-		if "key_pvr" not in self:
-			self["key_pvr"] = StaticText(_("PVR"))
-
-		self.on_change = on_change
-
+		self.setCancelMessage(None)
+		self.setRestartMessage(None)
+		self.onChangedEntry = []
+		self.onSave = []
+		self.manipulatedItems = []  # keep track of all manipulated items including ones that have been removed from self["config"].list (currently used by Setup.py)
+		if self.noNativeKeys not in self.onLayoutFinish:
+			self.onLayoutFinish.append(self.noNativeKeys)
 		if self.handleInputHelpers not in self["config"].onSelectionChanged:
 			self["config"].onSelectionChanged.append(self.handleInputHelpers)
+		if self.showHelpWindow not in self.onExecBegin:
+			self.onExecBegin.append(self.showHelpWindow)
+		if self.hideHelpWindow not in self.onExecEnd:
+			self.onExecEnd.append(self.hideHelpWindow)
 
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
+	def setCancelMessage(self, msg):
+		self.cancelMsg = _("Really close without saving settings?") if msg is None else msg
+
+	def setRestartMessage(self, msg):
+		self.restartMsg = _("Restart GUI now?") if msg is None else msg
+
+	def getCurrentItem(self):
+		return self["config"].getCurrent() and len(self["config"].getCurrent()) > 1 and self["config"].getCurrent()[1] or None
 
 	def getCurrentItem(self):
 		return self["config"].getCurrent() and self["config"].getCurrent()[1] or None
@@ -212,104 +263,157 @@ class ConfigListScreen:
 
 	def handleInputHelpers(self):
 		currConfig = self["config"].getCurrent()
-		if currConfig is not None and currConfig[1].__class__.__name__ in ('ConfigText', 'ConfigPassword'):
-			if "VKeyIcon" in self:
-				self["VirtualKB"].setEnabled(True)
-				self["VKeyIcon"].boolean = True
-			if "HelpWindow" in self and currConfig[1].help_window and currConfig[1].help_window.instance is not None:
+		if currConfig is not None:
+			if isinstance(currConfig[1], (ConfigInteger, ConfigMacText, ConfigSequence, ConfigText)):
+				self["editConfigActions"].setEnabled(True)
+			else:
+				self["editConfigActions"].setEnabled(False)
+			if isinstance(currConfig[1], ConfigSelection) and not isinstance(currConfig[1], ConfigNothing):
+				self["menuConfigActions"].setEnabled(True)
+				self["key_menu"].setText(_("MENU"))
+			else:
+				self["menuConfigActions"].setEnabled(False)
+				self["key_menu"].setText("")
+			if isinstance(currConfig[1], (ConfigText, ConfigMacText)) and "HelpWindow" in self and currConfig[1].help_window and currConfig[1].help_window.instance is not None:
 				helpwindowpos = self["HelpWindow"].getPosition()
-				from enigma import ePoint
 				currConfig[1].help_window.instance.move(ePoint(helpwindowpos[0], helpwindowpos[1]))
-		elif "VKeyIcon" in self:
-			self["VirtualKB"].setEnabled(False)
-			self["VKeyIcon"].boolean = False
-		if currConfig is not None and isinstance(currConfig[1], ConfigSelection) and not isinstance(currConfig[1], ConfigNothing):
-			self["key_pvr"].setText(_("PVR"))
+			if isinstance(currConfig[1], ConfigText):
+				self.showVirtualKeyBoard(True)
+			else:
+				self.showVirtualKeyBoard(False)
+			if "description" in self:
+				self["description"].text = self.getCurrentDescription()
+
+	def showVirtualKeyBoard(self, state):
+		if "VKeyIcon" in self:
+			self["VKeyIcon"].boolean = state
+			self["virtualKeyBoardActions"].setEnabled(state)
+
+	def showHelpWindow(self):
+		self.displayHelp(True)
+
+	def hideHelpWindow(self):
+		self.displayHelp(False)
+
+	def displayHelp(self, state):
+		if "config" in self and "HelpWindow" in self and self["config"].getCurrent() is not None and len(self["config"].getCurrent()) > 1:
+			currConf = self["config"].getCurrent()[1]
+			if isinstance(currConf, (ConfigText, ConfigMacText)) and currConf.help_window is not None and currConf.help_window.instance is not None:
+				if state:
+					currConf.help_window.show()
+				else:
+					currConf.help_window.hide()
+
+	def keySelect(self):
+		if isinstance(self.getCurrentItem(), ConfigBoolean):
+			self.keyToggle()
+		elif isinstance(self.getCurrentItem(), ConfigSelection):
+			self.keyMenu()
+		elif isinstance(self.getCurrentItem(), ConfigText) and not isinstance(self.getCurrentItem(), ConfigNumber):
+			self.keyText()
 		else:
-			self["key_pvr"].setText("")
-		if "description" in self:
-			self["description"].text = self.getCurrentDescription()
+			self["config"].handleKey(ACTIONKEY_SELECT, self.entryChanged)
 
-	def KeyText(self):
-		self["config"].hideHelp()
-		from Screens.VirtualKeyBoard import VirtualKeyBoard
-		self.session.openWithCallback(self.VirtualKeyBoardCallback, VirtualKeyBoard, title=self["config"].getCurrent()[0], text=self["config"].getCurrent()[1].getValue())
+	def keyOK(self):  # This is the deprecated version of keySelect!
+		self.keySelect()
 
-	def VirtualKeyBoardCallback(self, callback=None):
+	def keyText(self):
+		self.session.openWithCallback(self.keyTextCallback, VirtualKeyBoard, title=self.getCurrentEntry(), text=str(self.getCurrentValue()))
+
+	def keyTextCallback(self, callback=None):
 		if callback is not None:
+			prev = str(self.getCurrentValue())
 			self["config"].getCurrent()[1].setValue(callback)
-			self["config"].invalidate(self["config"].getCurrent())
-			self.__changed()
-		self["config"].showHelp()
+			self["config"].invalidateCurrent()
+			if callback != prev:
+				self.entryChanged()
 
-	def keyOK(self):
-		self["config"].handleKey(KEY_OK)
+	def keyMenu(self):
+		currConfig = self["config"].getCurrent()
+		if currConfig and currConfig[1].enabled and hasattr(currConfig[1], "description"):
+			self.session.openWithCallback(
+				self.keyMenuCallback, ChoiceBox, title=currConfig[0],
+				list=list(zip(currConfig[1].description, currConfig[1].choices)),
+				selection=currConfig[1].getIndex(),
+				keys=[]
+			)
 
-	def keyLeft(self):
-		self["config"].handleKey(KEY_LEFT)
-		self.changed()
+	def keyMenuCallback(self, answer):
+		if answer:
+			self["config"].getCurrent()[1].value = answer[1]
+			self["config"].invalidateCurrent()
+			self.entryChanged()
 
-	def keyRight(self):
-		self["config"].handleKey(KEY_RIGHT)
-		self.changed()
-
-	def keyHome(self):
-		self["config"].handleKey(KEY_HOME)
-		self.changed()
-
-	def keyEnd(self):
-		self["config"].handleKey(KEY_END)
-		self.changed()
-
-	def keyDelete(self):
-		self["config"].handleKey(KEY_DELETE)
-		self.changed()
-
-	def keyBackspace(self):
-		self["config"].handleKey(KEY_BACKSPACE)
-		self.changed()
-
-	def keyToggleOW(self):
-		self["config"].handleKey(KEY_TOGGLEOW)
-		self.changed()
-
-	def keyGotAscii(self):
-		self["config"].handleKey(KEY_ASCII)
-		self.changed()
-
-	def keyNumberGlobal(self, number):
-		self["config"].handleKey(KEY_0 + number)
-		self.changed()
-
-	def keyPageDown(self):
-		self["config"].pageDown()
+	def keyTop(self):
+		self["config"].moveTop()
 
 	def keyPageUp(self):
 		self["config"].pageUp()
 
-	def changed(self):
-		if self.on_change and self["config"].getNotifierNeeded():
-			self.on_change()
+	def keyUp(self):
+		self["config"].moveUp()
 
-	def keyFile(self):
-		selection = self["config"].getCurrent()
-		if selection and selection[1].enabled and hasattr(selection[1], "description"):
-			self.session.openWithCallback(
-				self.handleKeyFileCallback, ChoiceBox, selection[0],
-				list=list(zip(selection[1].description, selection[1].choices)),
-				selection=selection[1].choices.index(selection[1].value),
-				keys=[]
-			)
+	def keyFirst(self):
+		self["config"].handleKey(ACTIONKEY_FIRST, self.entryChanged)
 
-	def handleKeyFileCallback(self, answer):
-		if answer:
-			self["config"].getCurrent()[1].value = answer[1]
-			self["config"].invalidateCurrent()
-			self.changed()
+	def keyLeft(self):
+		self["config"].handleKey(ACTIONKEY_LEFT, self.entryChanged)
+
+	def keyRight(self):
+		self["config"].handleKey(ACTIONKEY_RIGHT, self.entryChanged)
+
+	def keyLast(self):
+		self["config"].handleKey(ACTIONKEY_LAST, self.entryChanged)
+
+	def keyDown(self):
+		self["config"].moveDown()
+
+	def keyPageDown(self):
+		self["config"].pageDown()
+
+	def keyBottom(self):
+		self["config"].moveBottom()
+
+	def keyBackspace(self):
+		self["config"].handleKey(ACTIONKEY_BACKSPACE, self.entryChanged)
+
+	def keyDelete(self):
+		self["config"].handleKey(ACTIONKEY_DELETE, self.entryChanged)
+
+	def keyErase(self):
+		self["config"].handleKey(ACTIONKEY_ERASE, self.entryChanged)
+
+	def keyToggle(self):
+		self["config"].handleKey(ACTIONKEY_TOGGLE, self.entryChanged)
+
+	def keyGotAscii(self):
+		self["config"].handleKey(ACTIONKEY_ASCII, self.entryChanged)
+
+	def keyNumberGlobal(self, number):
+		self["config"].handleKey(ACTIONKEY_0 + number, self.entryChanged)
+
+	def keySave(self):
+		for notifier in self.onSave:
+			notifier()
+		if self.saveAll():
+			self.session.openWithCallback(self.restartConfirm, MessageBox, self.restartMsg, default=True, type=MessageBox.TYPE_YESNO)
+		else:
+			self.close()
+
+	def restartConfirm(self, result):
+		if result:
+			self.session.open(TryQuitMainloop, retvalue=QUIT_RESTART)
+			self.close()
 
 	def saveAll(self):
-		for x in self["config"].list:
-			x[1].save()
+		restart = False
+		for item in set(self["config"].list + self.manipulatedItems):
+			if len(item) > 1:
+				if item[0].endswith("*") and item[1].isChanged():
+					restart = True
+				item[1].save()
+		configfile.save()
+		return restart
 
 	def addSaveNotifier(self, notifier):
 		if callable(notifier):
@@ -317,30 +421,69 @@ class ConfigListScreen:
 		else:
 			raise TypeError("[ConfigList] Error: Notifier must be callable!")
 
-	# keySave and keyCancel are just provided in case you need them.
-	# you have to call them by yourself.
-	def keySave(self):
-		self.saveAll()
-		self.close()
+	def removeSaveNotifier(self, notifier):
+		while notifier in self.onSave:
+			self.onSave.remove(notifier)
+
+	def clearSaveNotifiers(self):
+		self.onSave = []
+
+	def keyCancel(self):
+		self.closeConfigList(())
+
+	def addSaveNotifier(self, notifier):
+		if callable(notifier):
+			self.onSave.append(notifier)
+		else:
+			raise TypeError("[ConfigList] Error: Notifier must be callable!")
+
+	def closeRecursive(self):
+		self.closeConfigList((True,))
+
+	def closeConfigList(self, closeParameters=()):
+		if self["config"].isChanged() or self.manipulatedItems:
+			self.closeParameters = closeParameters
+			self.session.openWithCallback(self.cancelConfirm, MessageBox, self.cancelMsg, default=False, type=MessageBox.TYPE_YESNO)
+		else:
+			self.close(*closeParameters)
 
 	def cancelConfirm(self, result):
 		if not result:
-			self["config"].showHelp()
 			return
+		for item in set(self["config"].list + self.manipulatedItems):
+			if len(item) > 1:
+				item[1].cancel()
+		if not hasattr(self, "closeParameters"):
+			self.closeParameters = ()
+		self.close(*self.closeParameters)
 
-		for x in self["config"].list:
-			x[1].cancel()
-		self.close()
+	def createSummary(self):  # This should not be required if ConfigList is invoked via Setup (as it should).
+		from Screens.Setup import SetupSummary
+		return SetupSummary
 
-	def closeMenuList(self, recursive=False):
-		if self["config"].isChanged():
-			self["config"].hideHelp()
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"))
-		else:
-			self.close(recursive)
+	def run(self):  # Allow ConfigList based screens to be processed from the Wizard.
+		self.keySave()
 
-	def keyCancel(self):
-		self.closeMenuList()
+	def dummyConfigActions(self, value):  # Temporary support for legacy code and plugins that hasn't yet been updated.
+		self["configActions"].setEnabled(value)
+		self["navigationActions"].setEnabled(value)
+		self["menuConfigActions"].setEnabled(value)
+		self["charConfigActions"].setEnabled(value)
+		self["editConfigActions"].setEnabled(value)
 
-	def closeRecursive(self):
-		self.closeMenuList(True)
+	def dummyVKBActions(self, value):  # Temporary support for legacy code and plugins that hasn't yet been updated.
+		self["virtualKeyBoardActions"].setEnabled(value)
+
+
+class DummyActions:  # Temporary support for legacy code and plugins that hasn't yet been updated.
+	def setEnabled(self, enabled):
+		pass
+
+	def destroy(self):
+		pass
+
+	def execBegin(self):
+		pass
+
+	def execEnd(self):
+		pass

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -949,6 +949,12 @@ def InitUsageConfig():
 
 	config.osd.alpha_teletext = ConfigSelectionNumber(default=255, stepwidth=1, min=0, max=255, wraparound=False)
 
+	config.usage.setupShowDefault = ConfigSelection(default="spaces", choices=[
+		("", _("Don't show default")),
+		("spaces", _("Show default after description")),
+		("newline", _("Show default on new line"))
+	])
+
 	config.epg = ConfigSubsection()
 	config.epg.eit = ConfigYesNo(default=True)
 	config.epg.mhw = ConfigYesNo(default=False)

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -850,6 +850,141 @@ class ConfigMAC(ConfigSequence):
 		ConfigSequence.__init__(self, seperator=":", limits=[(0, 255), (0, 255), (0, 255), (0, 255), (0, 255), (0, 255)], default=default)
 
 
+class ConfigMacText(ConfigElement, NumericalTextInput):
+	def __init__(self, default="", visible_width=False):
+		ConfigElement.__init__(self)
+		NumericalTextInput.__init__(self, nextFunc=self.nextFunc, handleTimeout=False)
+
+		self.marked_pos = 0
+		self.allmarked = (default != "")
+		self.fixed_size = 17
+		self.visible_width = visible_width
+		self.offset = 0
+		self.overwrite = 17
+		self.help_window = None
+		self.value = self.default = default
+		self.lastValue = self.tostring(self.value)
+		self.useableChars = '0123456789ABCDEF'
+
+	def validateMarker(self):
+		textlen = len(self.text)
+		if self.marked_pos > textlen - 1:
+			self.marked_pos = textlen - 1
+		elif self.marked_pos < 0:
+			self.marked_pos = 0
+
+	def insertChar(self, ch, pos, owr):
+		if self.text[pos] == ':':
+			pos += 1
+		if owr or self.overwrite:
+			self.text = self.text[0:pos] + ch + self.text[pos + 1:]
+		elif self.fixed_size:
+			self.text = self.text[0:pos] + ch + self.text[pos:-1]
+		else:
+			self.text = self.text[0:pos] + ch + self.text[pos:]
+
+	def handleKey(self, key, callback=None):
+		prev = str(self.value)
+		if key == ACTIONKEY_LEFT:
+			self.timeout()
+			if self.allmarked:
+				self.marked_pos = len(self.text)
+				self.allmarked = False
+			else:
+				if self.text[self.marked_pos - 1] == ':':
+					self.marked_pos -= 2
+				else:
+					self.marked_pos -= 1
+		elif key == ACTIONKEY_RIGHT:
+			self.timeout()
+			if self.allmarked:
+				self.marked_pos = 0
+				self.allmarked = False
+			else:
+				if self.marked_pos < (len(self.text) - 1):
+					if self.text[self.marked_pos + 1] == ':':
+						self.marked_pos += 2
+					else:
+						self.marked_pos += 1
+		elif key in ACTIONKEY_NUMBERS:
+			owr = self.lastKey == getKeyNumber(key)
+			newChar = self.getKey(getKeyNumber(key))
+			self.insertChar(newChar, self.marked_pos, owr)
+		elif key == ACTIONKEY_TIMEOUT:
+			self.timeout()
+			if self.help_window:
+				self.help_window.update(self)
+			if self.text[self.marked_pos] == ':':
+				self.marked_pos += 1
+			return
+
+		if self.help_window:
+			self.help_window.update(self)
+		self.validateMarker()
+		if prev != str(self.value):
+			self.changed()
+			if callable(callback):
+				callback()
+
+	def nextFunc(self):
+		self.marked_pos += 1
+		self.validateMarker()
+		self.changed()
+
+	def getValue(self):
+		# print(f"[Config][getValue] {self.text}")
+		return str(self.text)
+
+	def setValue(self, val):
+		# print(f"[Config][setValue] val:{val}")
+		prev = self.text if hasattr(self, "text") else None
+		if val != prev:
+			self.text = val
+			self.changed()
+
+	value = property(getValue, setValue)
+	_value = property(getValue, setValue)
+
+	def getText(self):
+		# print(f"[Config][getText] {self.text}")
+		return self.text
+
+	def getMulti(self, selected):
+		# print(f"[Config][getMulti] {self.text}")
+		if self.visible_width:
+			if self.allmarked:
+				mark = list(range(0, min(self.visible_width, len(self.text))))
+			else:
+				mark = [self.marked_pos - self.offset]
+			return "mtext"[1 - selected:], str(self.text[self.offset:self.offset + self.visible_width]) + " ", mark
+		else:
+			if self.allmarked:
+				mark = list(range(0, len(self.text)))
+			else:
+				mark = [self.marked_pos]
+			return "mtext"[1 - selected:], str(self.text) + " ", mark
+
+	def onSelect(self, session):
+		self.allmarked = (self.value != "")
+		if session is not None:
+			from Screens.NumericalTextInputHelpDialog import NumericalTextInputHelpDialog
+			self.help_window = session.instantiateDialog(NumericalTextInputHelpDialog, self)
+			self.help_window.show()
+
+	def onDeselect(self, session):
+		self.marked_pos = 0
+		self.offset = 0
+		if self.help_window:
+			session.deleteDialog(self.help_window)
+			self.help_window = None
+
+	def getHTML(self, id):
+		return '<input type="text" name="' + id + '" value="' + self.value + '" /><br>\n'
+
+	def unsafeAssign(self, value):
+		self.value = str(value)
+
+
 class ConfigPosition(ConfigSequence):
 	def __init__(self, default, args):
 		ConfigSequence.__init__(self, seperator=",", limits=[(0, args[0]), (0, args[1]), (0, args[2]), (0, args[3])], default=default)
@@ -1293,73 +1428,6 @@ class ConfigSelectionInteger(ConfigSelection):
 class ConfigSelectionNumber(ConfigSelectionInteger):
 	def __init__(self, min, max, stepwidth, default=None, wraparound=False, units=None):
 		ConfigSelectionInteger.__init__(self, default, min, max, stepwidth, wraparound, units)
-
-
-class ConfigMACText(ConfigText):
-	def __init__(self, default="", visible_width=17):
-		ConfigText.__init__(self, default, fixed_size=True, visible_width=visible_width)
-		NumericalTextInput.setMode(self, "HexFastLogicalUpper")  # HexFastUpper
-		self.allmarked = False
-
-	def handleKey(self, key, callback=None):
-		if callable(callback):
-			self.callback = callback
-		prev = self.value
-		if key == ACTIONKEY_FIRST:
-			self.timeout()
-			self.markedPos = 0
-		elif key == ACTIONKEY_LEFT:
-			self.timeout()
-			self.markedPos -= 2 if self.text[self.markedPos - 1] == ":" else 1
-		elif key == ACTIONKEY_RIGHT:
-			self.timeout()
-			self.markedPos += 2 if self.markedPos < self.visible_width - 1 and self.text[self.markedPos + 1] == ":" else 1
-		elif key == ACTIONKEY_LAST:
-			self.timeout()
-			self.markedPos = len(self.text)
-		elif key == ACTIONKEY_ERASE:
-			self.timeout()
-			self.text = self.text[2].join(["00"] * 6)
-			self.markedPos = 0
-		elif key in ACTIONKEY_NUMBERS:
-			owr = self.lastKey == getKeyNumber(key)
-			newChar = self.getKey(getKeyNumber(key))
-			self.insertChar(newChar, self.markedPos, owr)
-		elif key == ACTIONKEY_TIMEOUT:
-			self.timeout()
-			if self.help_window:
-				self.help_window.update(self)
-			if self.text[self.markedPos] == ":":
-				self.markedPos += 1
-			return
-		if self.help_window:
-			self.help_window.update(self)
-		self.validateMarker()
-		if self.value != prev:
-			self.changed()
-			if self.callback:
-				self.callback()
-
-	def validateMarker(self):
-		textlen = len(self.text)
-		if self.markedPos > textlen - 1:
-			self.markedPos = textlen - 1
-		elif self.markedPos < 0:
-			self.markedPos = 0
-
-	def insertChar(self, ch, pos, owr):
-		if self.text[pos] == ":":
-			pos += 1
-		ConfigText.insertChar(self, ch, pos, owr)
-
-	def onSelect(self, session):
-		ConfigText.onSelect(self, session)
-		self.allmarked = False
-
-
-class ConfigMacText(ConfigMACText):  # Deprecated class name.
-	def __init__(self, default="", visible_width=17):
-		ConfigMACText.__init__(self, default=default, visible_width=visible_width)
 
 
 class ConfigNumber(ConfigText):

--- a/lib/python/Components/config.py
+++ b/lib/python/Components/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
-from os import fsync, rename, sep
+from os import fsync, rename, sep, path as os_path
 from os.path import realpath
 from copy import copy as shallowcopy
-from time import localtime, strftime, struct_time
+from time import localtime, strftime, struct_time, mktime
 
 from enigma import getPrevAsciiCode
 
@@ -66,7 +66,7 @@ def getKeyNumber(key):
 
 
 def getConfigListEntry(*args):
-	assert len(args) > 0, "getConfigListEntry needs a minimum of one argument (descr, configElement)"
+	assert len(args) > 0, "getConfigListEntry needs a minimum of one argument (descr)"
 	return args
 
 
@@ -109,7 +109,7 @@ class ConfigElement(object):
 		self.__notifiers = None
 		self.__notifiers_final = None
 		self.enabled = True
-		self.callNotifiersOnSaveAndCancel = False
+		self.callNotifiersOnSaveAndCancel = False  # this is here for compatibility only. Do not use.
 
 	def getNotifiers(self):
 		if self.__notifiers is None:
@@ -133,13 +133,10 @@ class ConfigElement(object):
 
 	# you need to override this to do input validation
 	def setValue(self, value):
+		prev = str(self._value) if hasattr(self, "_value") and len(self._value) else None
 		self._value = value
-		self.changed()
-
-	def getNotifierNeeded(self):
-		if self.prev_value != self.value:
-			self.prev_value = self.value
-			return True
+		if str(self._value) != prev:
+			self.changed()
 
 	def getValue(self):
 		return self._value
@@ -157,6 +154,7 @@ class ConfigElement(object):
 			self.value = self.default
 		else:
 			self.value = self.fromString(sv)
+		self.lastValue = self.tostring(self.value)
 
 	def toString(self, value):
 		return str(value)
@@ -171,19 +169,20 @@ class ConfigElement(object):
 			self.saved_value = None
 		else:
 			self.saved_value = self.toString(self.value)
-		if self.callNotifiersOnSaveAndCancel:
-			self.changed()
+
+		if self.lastValue != self.tostring(self.value):
+			self.lastValue = self.tostring(self.value)
+			self.changedFinal()
 
 	def cancel(self):
 		self.load()
-		if self.callNotifiersOnSaveAndCancel:
-			self.changed()
 
 	def isChanged(self):
-		sv = self.saved_value
-		if sv is None and self.value == self.default:
-			return False
-		return self.toString(self.value) != sv
+		# NOTE - self.saved_value should already be stringified!
+		#        self.default may be a string or None
+		sv = self.saved_value or self.tostring(self.default)
+		strv = self.tostring(self.value)
+		return strv != sv
 
 	def changed(self):
 		if self.__notifiers:
@@ -196,6 +195,17 @@ class ConfigElement(object):
 				x(self)
 
 	def addNotifier(self, notifier, initial_call=True, immediate_feedback=True):
+		# "initial_call=True" triggers the notifier as soon as "addNotifier" is encountered in the code.
+		#
+		# "initial_call=False" skips the above activation of the notifier.
+		#
+		# "immediate_feedback=True" notifiers are called on every single change of the config item,
+		# e.g. if going left/right through a ConfigSelection it will trigger on every step.
+		#
+		# "immediate_feedback=False" notifiers are called on ConfigElement.save() only.
+		#
+		# Use of the "self.callNotifiersOnSaveAndCancel" flag serves no purpose in the current code.
+		#
 		assert callable(notifier), "notifiers must be callable"
 		if immediate_feedback:
 			self.notifiers.append(notifier)
@@ -215,6 +225,18 @@ class ConfigElement(object):
 	def removeNotifier(self, notifier):
 		notifier in self.notifiers and self.notifiers.remove(notifier)
 		notifier in self.notifiers_final and self.notifiers_final.remove(notifier)
+		try:
+			del self.__notifiers[str(notifier)]
+		except BaseException:
+			pass
+		try:
+			del self.__notifiers_final[str(notifier)]
+		except BaseException:
+			pass
+
+	def clearNotifiers(self):
+		self.__notifiers = {}
+		self.__notifiers_final = {}
 
 	def disableSave(self):
 		self.save_disabled = True
@@ -226,9 +248,7 @@ class ConfigElement(object):
 		pass
 
 	def onDeselect(self, session):
-		if not self.lastValue == self.value:
-			self.changedFinal()
-			self.lastValue = self.value
+		pass
 
 	def hideHelp(self, session):
 		pass
@@ -352,6 +372,10 @@ class descriptionList(choicesList):  # XXX: we might want a better name for this
 			self.choices[index] = value
 
 #
+# ConfigSelection is a "one of.."-type.
+# it has the "choices", usually a list, which contains
+# (id, desc)-tuples (or just only the ids, in case the id
+# will be used as description)
 # ConfigSelection is a "one of.."-type.  it has the "choices", usually
 # a list, which contains (id, desc)-tuples (or just only the ids, in
 # case str(id) will be used as description)
@@ -390,6 +414,8 @@ class ConfigSelection(ConfigElement):
 
 		self._descr = None
 		self.default = self._value = self.lastValue = self.prev_value = default
+		self.default = self._value = default
+		self.lastValue = self.tostring(default)
 		self.graphic = graphic
 
 	def setSelectionList(self, choices, default=None):
@@ -416,12 +442,14 @@ class ConfigSelection(ConfigElement):
 		return list(zip(self.choices.__list__(), self.description.__list__()))
 
 	def setValue(self, value):
+		prev = str(self._value) if hasattr(self, "_value") else None
 		if str(value) in map(str, self.choices):
 			self._value = self.choices[self.choices.index(value)]
 		else:
 			self._value = self.default
 		self._descr = None
-		self.changed()
+		if prev != str(self._value):
+			self.changed()
 
 	def toString(self, val):
 		return str(val)
@@ -438,6 +466,7 @@ class ConfigSelection(ConfigElement):
 			self.value = self.default
 		else:
 			self.value = self.choices[self.choices.index(sv)]
+		self.lastValue = self.tostring(self.value)
 
 	def setCurrentText(self, text):
 		i = self.choices.index(self.value)
@@ -453,7 +482,7 @@ class ConfigSelection(ConfigElement):
 	index = property(getIndex)
 
 	# GUI
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		count = len(self.choices)
 		if count > 1:
 			prev = str(self.value)
@@ -466,8 +495,8 @@ class ConfigSelection(ConfigElement):
 				self.value = self.choices[0]
 			elif key == ACTIONKEY_LAST:
 				self.value = self.choices[count - 1]
-			if str(self.value) != prev:
-				self.changed()
+			if str(self.value) != prev and callable(callback):
+				callback()
 
 	def selectNext(self):
 		nchoices = len(self.choices)
@@ -483,11 +512,12 @@ class ConfigSelection(ConfigElement):
 		if self._descr is None:
 			self._descr = self.description[self.value]
 		from Components.config import config
-		from skin import switchPixmap
-		if self.graphic and config.usage.boolean_graphic.value == "true" and "menu_on" in switchPixmap and "menu_off" in switchPixmap:
-			pixmap = "menu_on" if self._descr in (_('True'), _('true'), _('Yes'), _('yes'), _('Enable'), _('enable'), _('Enabled'), _('enabled'), _('On'), _('on')) else "menu_off" if self._descr in (_('False'), _('false'), _('No'), _('no'), _("Disable"), _('disable'), _('Disabled'), _('disabled'), _('Off'), _('off'), _('None'), _('none')) else None
-			if pixmap:
-				return ('pixmap', switchPixmap[pixmap])
+		if self.graphic and config.usage.boolean_graphic.value == "true":
+			from skin import switchPixmap
+			if "menu_on" in switchPixmap and "menu_off" in switchPixmap:
+				pixmap = "menu_on" if self._descr in (_('True'), _('true'), _('Yes'), _('yes'), _('Enable'), _('enable'), _('Enabled'), _('enabled'), _('On'), _('on')) else "menu_off" if self._descr in (_('False'), _('false'), _('No'), _('no'), _("Disable"), _('disable'), _('Disabled'), _('disabled'), _('Off'), _('off'), _('None'), _('none')) else None
+				if pixmap:
+					return ('pixmap', switchPixmap[pixmap])
 		return ("text", self._descr)
 
 	# HTML
@@ -508,86 +538,82 @@ class ConfigSelection(ConfigElement):
 
 	description = property(lambda self: descriptionList(self.choices.choices, self.choices.type))
 
-# a binary decision.
+# This is the control, and base class, for binary decisions.
 #
-# several customized versions exist for different
-# descriptions.
+# Several customized versions exist for different descriptions.
 #
-
-
 class ConfigBoolean(ConfigElement):
-	def __init__(self, default=False, descriptions={False: _("false"), True: _("true")}, graphic=True):
+	def __init__(self, default=False, descriptions={False: _("False"), True: _("True")}, graphic=True):
 		ConfigElement.__init__(self)
+		self.value = self.default = default
+		self.lastValue = self.tostring(self.value)
 		self.descriptions = descriptions
-		self.value = self.lastValue = self.prev_value = self.default = default
 		self.graphic = graphic
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
+		value = bool(self.value)
 		if key in (ACTIONKEY_TOGGLE, ACTIONKEY_SELECT, ACTIONKEY_LEFT, ACTIONKEY_RIGHT):
-			self.value = not self.value
+			value = not value
 		elif key == ACTIONKEY_FIRST:
-			self.value = False
+			value = False
 		elif key == ACTIONKEY_LAST:
-			self.value = True
+			value = True
+		if self.value != value:
+			self.value = value
+			if callable(callback):
+				callback()
+
+	def fromstring(self, val):
+		return str(val).lower() in self.trueValues()
+
+	def tostring(self, value):
+		return "True" if value and str(value).lower() in self.trueValues() else "False"
+		# Use the following if settings should be saved using the same values as displayed to the user.
+		# self.descriptions[True] if value or str(value).lower() in ("1", "enable", "on", "true", "yes") else self.descriptions[True]
+
+	def toDisplayString(self, value):
+		return self.descriptions[True] if value or str(value).lower() in self.trueValues() else self.descriptions[False]
 
 	def getText(self):
 		return self.descriptions[self.value]
 
 	def getMulti(self, selected):
 		from Components.config import config
-		from skin import switchPixmap
-		if self.graphic and config.usage.boolean_graphic.value in ("true", "only_bool") and "menu_on" in switchPixmap and "menu_off" in switchPixmap:
-			return ('pixmap', switchPixmap["menu_on" if self.value else "menu_off"])
+		if self.graphic and config.usage.boolean_graphic.value in ("true", "only_bool"):
+			from skin import switchPixmap
+			if "menu_on" in switchPixmap and "menu_off" in switchPixmap:
+				return ('pixmap', switchPixmap["menu_on" if self.value else "menu_off"])
 		return ("text", self.descriptions[self.value])
 
-	def toString(self, value):
-		if not value:
-			return "false"
-		else:
-			return "true"
+	# For HTML Interface - Is this still used?
 
-	def fromString(self, val):
-		if val == "true":
-			return True
-		else:
-			return False
+	def getHTML(self, id):  # DEBUG: Is this still used?
+		return "<input type=\"checkbox\" name=\"%s\" value=\"1\"%s />" % (id, " checked=\"checked\"" if self.value else "")
 
-	def getHTML(self, id):
-		if self.value:
-			checked = ' checked="checked"'
-		else:
-			checked = ''
-		return '<input type="checkbox" name="' + id + '" value="1" ' + checked + " />"
+	def unsafeAssign(self, value):  # DEBUG: Is this still used?
+		self.value = value.lower() in self.trueValues()
 
-	# this is FLAWED. and must be fixed.
-	def unsafeAssign(self, value):
-		if value == "1":
-			self.value = True
-		else:
-			self.value = False
-
-	def onDeselect(self, session):
-		if not self.lastValue == self.value:
-			self.changedFinal()
-			self.lastValue = self.value
+	def trueValues(self):
+		# This should be set in the __init__() but has been done this way as a workaround for a stupid broken plugin that fails to call ConfigBoolean.__init__().
+		return ("1", "enable", "on", "true", "yes")
 
 	def toDisplayString(self, value):
 		return self.descriptions[True] if value or str(value).lower() in self.trueValues else self.descriptions[False]
 
 
-class ConfigYesNo(ConfigBoolean):
+class ConfigEnableDisable(ConfigBoolean):
 	def __init__(self, default=False, graphic=True):
-		ConfigBoolean.__init__(self, default=default, descriptions={False: _("no"), True: _("yes")}, graphic=graphic)
+		ConfigBoolean.__init__(self, default=default, descriptions={False: _("Disable"), True: _("Enable")}, graphic=graphic)
 
 
 class ConfigOnOff(ConfigBoolean):
 	def __init__(self, default=False, graphic=True):
-		ConfigBoolean.__init__(self, default=default, descriptions={False: _("off"), True: _("on")}, graphic=graphic)
+		ConfigBoolean.__init__(self, default=default, descriptions={False: _("Off"), True: _("On")}, graphic=graphic)
 
 
-class ConfigEnableDisable(ConfigBoolean):
+class ConfigYesNo(ConfigBoolean):
 	def __init__(self, default=False, graphic=True):
-		ConfigBoolean.__init__(self, default=default, descriptions={False: _("disable"), True: _("enable")}, graphic=graphic)
+		ConfigBoolean.__init__(self, default=default, descriptions={False: _("No"), True: _("Yes")}, graphic=graphic)
 
 
 class ConfigDateTime(ConfigElement):
@@ -595,21 +621,25 @@ class ConfigDateTime(ConfigElement):
 		ConfigElement.__init__(self)
 		self.increment = increment
 		self.formatstring = formatstring
-		self.value = self.lastValue = self.prev_value = self.default = int(default)
+		self.value = self.default = int(default)
+		self.lastValue = self.tostring(self.value)
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
+		prev = str(self.value)
 		if key == ACTIONKEY_LEFT:
 			self.value -= self.increment
 		elif key == ACTIONKEY_RIGHT:
 			self.value += self.increment
 		elif key == ACTIONKEY_FIRST or key == ACTIONKEY_LAST:
 			self.value = self.default
+		if str(self.value) != prev and callable(callback):
+			callback()
 
 	def getText(self):
 		return strftime(self.formatstring, localtime(self.value))
 
 	def getMulti(self, selected):
-		return ("text", strftime(self.formatstring, localtime(self.value)))
+		return "text", strftime(self.formatstring, localtime(self.value))
 
 	def fromString(self, val):
 		return int(val)
@@ -645,7 +675,8 @@ class ConfigSequence(ConfigElement):
 		self.blockLen = [len(str(x[1])) for x in limits]
 		self.totalLen = sum(self.blockLen) - 1
 		self.censor = censor
-		self.lastValue = self.prev_value = self.default = default
+		self.default = default
+		self.lastValue = self.tostring(self.value)
 		self.value = shallowcopy(default)
 		self.hidden = censor != ""
 		self.endNotifier = None
@@ -690,8 +721,8 @@ class ConfigSequence(ConfigElement):
 			self._value[blockNumber] = newvalue
 			self.markedPos += 1
 			self.validate()
-			# if self._value != prev:
-			self.changed()
+		if not isinstance(self, ConfigClock) and prev != str(self._value):  # callback for ConfigClock handled in ConfigClock
+			self.changed()  # this is here only because SetValue() has not been called
 			if callable(callback):
 				callback()
 
@@ -722,9 +753,9 @@ class ConfigSequence(ConfigElement):
 		(value, mPos) = self.genText()
 		# Only mark cursor when we are selected.  (This code is heavily ink optimized!)
 		if self.enabled:
-			return ("mtext"[1 - selected:], value, [mPos])
+			return "mtext"[1 - selected:], value, [mPos]
 		else:
-			return ("text", value)
+			return "text", value
 
 	def genText(self):
 		value = ""
@@ -740,7 +771,7 @@ class ConfigSequence(ConfigElement):
 			else:
 				value += (self.censor * len(str(self.limits[num][1])))
 			num += 1
-		return (value, mPos)
+		return value, mPos
 
 	def fromString(self, value):
 		ret = [int(x) for x in value.split(self.seperator)]
@@ -779,7 +810,15 @@ class ConfigIP(ConfigSequence):
 		self.overwrite = True
 		self.auto_jump = auto_jump
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
+		prev = str(self.value)
+		self.execHandleKey(key)
+		if prev != str(self.value):
+			self.changed()
+			if callable(callback):
+				callback()
+
+	def execHandleKey(self, key):
 		if key == ACTIONKEY_FIRST:
 			self.markedPos = 0
 			self.overwrite = True
@@ -816,13 +855,13 @@ class ConfigIP(ConfigSequence):
 			else:
 				newValue = (self._value[self.markedPos] * 10) + number
 				if self.auto_jump and newValue > self.limits[self.markedPos][1] and self.markedPos < len(self.limits) - 1:
-					self.handleKey(ACTIONKEY_RIGHT)
-					self.handleKey(key)
+					self.execHandleKey(ACTIONKEY_RIGHT)
+					self.execHandleKey(key)
 					return
 				else:
 					self._value[self.markedPos] = newValue
 			if len(str(self._value[self.markedPos])) >= self.blockLen[self.markedPos]:
-				self.handleKey(ACTIONKEY_RIGHT)
+				self.execHandleKey(ACTIONKEY_RIGHT)
 			self.validate()
 			if self._value != prev:
 				self.changed()
@@ -850,6 +889,141 @@ class ConfigMAC(ConfigSequence):
 		ConfigSequence.__init__(self, seperator=":", limits=[(0, 255), (0, 255), (0, 255), (0, 255), (0, 255), (0, 255)], default=default)
 
 
+class ConfigMacText(ConfigElement, NumericalTextInput):
+	def __init__(self, default="", visible_width=False):
+		ConfigElement.__init__(self)
+		NumericalTextInput.__init__(self, nextFunc=self.nextFunc, handleTimeout=False)
+
+		self.marked_pos = 0
+		self.allmarked = (default != "")
+		self.fixed_size = 17
+		self.visible_width = visible_width
+		self.offset = 0
+		self.overwrite = 17
+		self.help_window = None
+		self.value = self.default = default
+		self.lastValue = self.tostring(self.value)
+		self.useableChars = '0123456789ABCDEF'
+
+	def validateMarker(self):
+		textlen = len(self.text)
+		if self.marked_pos > textlen - 1:
+			self.marked_pos = textlen - 1
+		elif self.marked_pos < 0:
+			self.marked_pos = 0
+
+	def insertChar(self, ch, pos, owr):
+		if self.text[pos] == ':':
+			pos += 1
+		if owr or self.overwrite:
+			self.text = self.text[0:pos] + ch + self.text[pos + 1:]
+		elif self.fixed_size:
+			self.text = self.text[0:pos] + ch + self.text[pos:-1]
+		else:
+			self.text = self.text[0:pos] + ch + self.text[pos:]
+
+	def handleKey(self, key, callback=None):
+		prev = str(self.value)
+		if key == ACTIONKEY_LEFT:
+			self.timeout()
+			if self.allmarked:
+				self.marked_pos = len(self.text)
+				self.allmarked = False
+			else:
+				if self.text[self.marked_pos - 1] == ':':
+					self.marked_pos -= 2
+				else:
+					self.marked_pos -= 1
+		elif key == ACTIONKEY_RIGHT:
+			self.timeout()
+			if self.allmarked:
+				self.marked_pos = 0
+				self.allmarked = False
+			else:
+				if self.marked_pos < (len(self.text) - 1):
+					if self.text[self.marked_pos + 1] == ':':
+						self.marked_pos += 2
+					else:
+						self.marked_pos += 1
+		elif key in ACTIONKEY_NUMBERS:
+			owr = self.lastKey == getKeyNumber(key)
+			newChar = self.getKey(getKeyNumber(key))
+			self.insertChar(newChar, self.marked_pos, owr)
+		elif key == ACTIONKEY_TIMEOUT:
+			self.timeout()
+			if self.help_window:
+				self.help_window.update(self)
+			if self.text[self.marked_pos] == ':':
+				self.marked_pos += 1
+			return
+
+		if self.help_window:
+			self.help_window.update(self)
+		self.validateMarker()
+		if prev != str(self.value):
+			self.changed()
+			if callable(callback):
+				callback()
+
+	def nextFunc(self):
+		self.marked_pos += 1
+		self.validateMarker()
+		self.changed()
+
+	def getValue(self):
+		# print(f"[Config][getValue] {self.text}")
+		return str(self.text)
+
+	def setValue(self, val):
+		# print(f"[Config][setValue] val:{val}")
+		prev = self.text if hasattr(self, "text") else None
+		if val != prev:
+			self.text = val
+			self.changed()
+
+	value = property(getValue, setValue)
+	_value = property(getValue, setValue)
+
+	def getText(self):
+		# print(f"[Config][getText] {self.text}")
+		return self.text
+
+	def getMulti(self, selected):
+		# print(f"[Config][getMulti] {self.text}")
+		if self.visible_width:
+			if self.allmarked:
+				mark = list(range(0, min(self.visible_width, len(self.text))))
+			else:
+				mark = [self.marked_pos - self.offset]
+			return "mtext"[1 - selected:], str(self.text[self.offset:self.offset + self.visible_width]) + " ", mark
+		else:
+			if self.allmarked:
+				mark = list(range(0, len(self.text)))
+			else:
+				mark = [self.marked_pos]
+			return "mtext"[1 - selected:], str(self.text) + " ", mark
+
+	def onSelect(self, session):
+		self.allmarked = (self.value != "")
+		if session is not None:
+			from Screens.NumericalTextInputHelpDialog import NumericalTextInputHelpDialog
+			self.help_window = session.instantiateDialog(NumericalTextInputHelpDialog, self)
+			self.help_window.show()
+
+	def onDeselect(self, session):
+		self.marked_pos = 0
+		self.offset = 0
+		if self.help_window:
+			session.deleteDialog(self.help_window)
+			self.help_window = None
+
+	def getHTML(self, id):
+		return '<input type="text" name="' + id + '" value="' + self.value + '" /><br>\n'
+
+	def unsafeAssign(self, value):
+		self.value = str(value)
+
+
 class ConfigPosition(ConfigSequence):
 	def __init__(self, default, args):
 		ConfigSequence.__init__(self, seperator=",", limits=[(0, args[0]), (0, args[1]), (0, args[2]), (0, args[3])], default=default)
@@ -857,6 +1031,13 @@ class ConfigPosition(ConfigSequence):
 
 class ConfigClock(ConfigSequence):
 	def __init__(self, default):
+		# dafault can either be a timestamp
+		# or an (hours, minutes) tuple.
+		if isinstance(default, tuple):
+			itemList = list(localtime())
+			itemList[3] = default[0]  # hours
+			itemList[4] = default[1]  # minutes
+			default = int(mktime(tuple(itemList)))
 		self.time = localtime(default)
 		ConfigSequence.__init__(self, seperator=":", limits=[(0, 23), (0, 59)], default=[self.time.tm_hour, self.time.tm_min])
 
@@ -1017,7 +1198,8 @@ class ConfigFloat(ConfigSequence):
 
 	floatint = property(getFloatInt, setFloatInt)
 
-# an editable text...
+# An editable text item.
+#
 
 
 class ConfigText(ConfigElement, NumericalTextInput):
@@ -1032,7 +1214,8 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		self.offset = 0
 		self.overwrite = fixed_size
 		self.help_window = None
-		self.value = self.lastValue = self.prev_value = self.default = default
+		self.value = self.default = default
+		self.lastValue = self.tostring(self.value)
 
 	def validateMarker(self):
 		textlen = len(self.text)
@@ -1053,7 +1236,7 @@ class ConfigText(ConfigElement, NumericalTextInput):
 				else:
 					self.offset = self.markedPos - self.visible_width + 1
 			if self.offset > 0 and self.offset + self.visible_width > textlen:
-				self.offset = max(0, len - self.visible_width)
+				self.offset = max(0, textlen - self.visible_width)
 
 	def insertChar(self, ch, pos, owr):
 		if owr or self.overwrite:
@@ -1078,7 +1261,10 @@ class ConfigText(ConfigElement, NumericalTextInput):
 			self.text = ""
 		self.markedPos = 0
 
-	def handleKey(self, key):  # This will not change anything on the value itself so we can handle it here in GUI element.
+	def handleKey(self, key, callback=None):
+		# This will not change anything on the value itself
+		# so we can handle it here in gui element.
+		prev = str(self.value)
 		if key == ACTIONKEY_FIRST:
 			self.timeout()
 			self.allmarked = False
@@ -1154,7 +1340,10 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		if self.help_window:
 			self.help_window.update(self)
 		self.validateMarker()
-		self.changed()
+		if prev != str(self.value):
+			self.changed()
+			if callable(callback):
+				callback()
 
 	def nextFunc(self):
 		self.markedPos += 1
@@ -1165,27 +1354,32 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		return self.text
 
 	def setValue(self, val):
-		self.text = val
+		prev = self.text if hasattr(self, "text") else None
+		if val != prev:
+			self.text = val
+			self.changed()
 
 	value = property(getValue, setValue)
 	_value = property(getValue, setValue)
 
 	def getText(self):
+		# print(f"[Config][getText2] {self.text}")
 		return self.text
 
 	def getMulti(self, selected):
+		# print(f"[Config][getMulti2] {self.text}")
 		if self.visible_width:
 			if self.allmarked:
 				mark = list(range(0, min(self.visible_width, len(self.text))))
 			else:
 				mark = [self.markedPos - self.offset]
-			return ("mtext"[1 - selected:], self.text[self.offset:self.offset + self.visible_width] + " ", mark)
+			return "mtext"[1 - selected:], str(self.text[self.offset:self.offset + self.visible_width]) + " ", mark
 		else:
 			if self.allmarked:
 				mark = list(range(0, len(self.text)))
 			else:
 				mark = [self.markedPos]
-			return ("mtext"[1 - selected:], self.text + " ", mark)
+			return "mtext"[1 - selected:], str(self.text) + " ", mark
 
 	def onSelect(self, session):
 		self.allmarked = (self.value != "")
@@ -1200,9 +1394,6 @@ class ConfigText(ConfigElement, NumericalTextInput):
 		if self.help_window:
 			session.deleteDialog(self.help_window)
 			self.help_window = None
-		if not self.lastValue == self.value:
-			self.changedFinal()
-			self.lastValue = self.value
 
 	def hideHelp(self, session):
 		if session is not None and self.help_window is not None:
@@ -1231,7 +1422,7 @@ class ConfigPassword(ConfigText):
 		mtext, text, mark = ConfigText.getMulti(self, selected)
 		if self.hidden:
 			text = self.censor * len(text)  # For more security a fixed length string can be used!
-		return (mtext, text, mark)
+		return mtext, text, mark
 
 	def onSelect(self, session):
 		ConfigText.onSelect(self, session)
@@ -1269,7 +1460,7 @@ class ConfigSelectionInteger(ConfigSelection):
 		self.units = units
 		ConfigSelection.__init__(self, choices=[(x, (ngettext(units[0], units[1], x) % x if units and isinstance(units, (list, tuple)) else str(x))) for x in range(first, last + 1, step)], default=default)
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		if not self.wrap:
 			if key == ACTIONKEY_RIGHT and self.choices.index(self.value) == len(self.choices) - 1:
 				return
@@ -1323,7 +1514,7 @@ class ConfigNumber(ConfigText):
 				if callable(callback):
 					callback()
 		else:
-			ConfigText.handleKey(self, key)
+			ConfigText.handleKey(self, key, callback)
 
 	def validateMarker(self):
 		pos = len(self.text) - self.markedPos
@@ -1362,7 +1553,7 @@ class ConfigDirectory(ConfigText):
 	def __init__(self, default="", visible_width=60):
 		ConfigText.__init__(self, default, fixed_size=True, visible_width=visible_width)
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		pass
 
 	def getValue(self):
@@ -1378,7 +1569,7 @@ class ConfigDirectory(ConfigText):
 
 	def getMulti(self, selected):
 		if self.text == "":
-			return ("mtext"[1 - selected:], _("List of storage devices"), list(range(0)))
+			return "mtext"[1 - selected:], _("List of storage devices"), list(range(0))
 		else:
 			return ConfigText.getMulti(self, selected)
 
@@ -1454,31 +1645,25 @@ class ConfigSatlist(ConfigSelection):
 	orbital_position = property(getOrbitalPosition)
 
 
+# This is the control, and base class, for a set of selection toggle fields.
+#
 class ConfigSet(ConfigElement):
-	def __init__(self, choices, default=[]):
+	def __init__(self, choices, default=None):
 		ConfigElement.__init__(self)
 		if isinstance(choices, list):
 			choices.sort()
 			self.choices = choicesList(choices, choicesList.LIST_TYPE_LIST)
 		else:
-			assert False, "ConfigSet choices must be a list!"
+			assert False, "[Config] Error: 'ConfigSet' choices must be a list!"
 		if default is None:
 			default = []
-		self.pos = -1
 		default.sort()
-		self.lastValue = self.default = self.prev_value = default
+		self.default = default
 		self.value = default[:]
+		self.lastValue = self.tostring(self.value)
+		self.pos = 0
 
-	def toggleChoice(self, choice):
-		value = self.value
-		if choice in value:
-			value.remove(choice)
-		else:
-			value.append(choice)
-			value.sort()
-		self.changed()
-
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		if key == ACTIONKEY_FIRST:
 			self.pos = 0
 		elif key == ACTIONKEY_LEFT:
@@ -1498,6 +1683,15 @@ class ConfigSet(ConfigElement):
 			self.value = value
 			self.changed()
 
+	def load(self):
+		ConfigElement.load(self)
+		if not self.value:
+			self.value = []
+		if not isinstance(self.value, list):
+			self.value = list(self.value)
+		self.value.sort()
+		self.lastValue = self.tostring(self.value[:])
+
 	def genString(self, lst):
 		res = ""
 		for x in lst:
@@ -1505,27 +1699,25 @@ class ConfigSet(ConfigElement):
 		return res
 
 	def getText(self):
-		return self.genString(self.value)
+		return " ".join([self.description[x] for x in self.value])
 
 	def getMulti(self, selected):
-		if not selected or self.pos == -1:
-			return ("text", self.genString(self.value))
+		if selected:
+			text = []
+			pos = 0
+			start = 0
+			end = 0
+			for item in self.choices:
+				itemStr = str(item)
+				text.append(" %s " % itemStr if item in self.value else "(%s)" % itemStr)
+				length = 2 + len(itemStr)
+				if item == self.choices[self.pos]:
+					start = pos
+					end = start + length
+				pos += length
+			return "mtext", "".join(text), list(range(start, end))
 		else:
-			tmp = self.value[:]
-			ch = self.choices[self.pos]
-			mem = ch in self.value
-			if not mem:
-				tmp.append(ch)
-				tmp.sort()
-			ind = tmp.index(ch)
-			val1 = self.genString(tmp[:ind])
-			val2 = " " + self.genString(tmp[ind + 1:])
-			if mem:
-				chstr = " " + self.description[ch] + " "
-			else:
-				chstr = "(" + self.description[ch] + ")"
-			len_val1 = len(val1)
-			return ("mtext", val1 + chstr + val2, list(range(len_val1, len_val1 + len(chstr))))
+			return "text", " ".join([self.description[x] for x in self.value])
 
 	def onDeselect(self, session):
 		self.pos = -1
@@ -1540,7 +1732,8 @@ class ConfigSet(ConfigElement):
 		return ", ".join([self.description[x] for x in value])
 
 	def fromString(self, val):
-		return eval(val)
+		# self.pos = 0  # Enable this to reset the position marker to the first element.
+		pass
 
 	description = property(lambda self: descriptionList(self.choices.choices, choicesList.LIST_TYPE_LIST))
 
@@ -1553,6 +1746,8 @@ class ConfigDictionarySet(ConfigElement):
 		self.value = self.default
 
 	def setValue(self, value):
+		if value == self.dirs:
+			return
 		if isinstance(value, dict):
 			self.dirs = value
 			self.changed()
@@ -1614,7 +1809,9 @@ class ConfigDictionarySet(ConfigElement):
 
 
 class ConfigLocations(ConfigElement):
-	def __init__(self, default=[], visible_width=False):
+	def __init__(self, default=None, visible_width=False):
+		if not default:
+			default = []
 		ConfigElement.__init__(self)
 		self.visible_width = visible_width
 		self.pos = -1
@@ -1629,9 +1826,10 @@ class ConfigLocations(ConfigElement):
 		add = [x for x in value if x not in loc]
 		diff = add + [x for x in loc if x not in value]
 		locations = [x for x in locations if x[0] not in diff] + [[x, self.getMountpoint(x), True, True] for x in add]
-		locations.sort(key=lambda x: x[0])
-		self.locations = locations
-		self.changed()
+		# locations.sort(key = lambda x: x[0]) # Do not sort here. Fix the input. config.py should not be modifying any list sent in by the calling code.
+		if self.locations != locations:
+			self.locations = locations
+			self.changed()
 
 	def getValue(self):
 		self.checkChangedMountpoints()
@@ -1690,7 +1888,7 @@ class ConfigLocations(ConfigElement):
 				x[2] = False
 
 	def refreshMountpoints(self):
-		self.mountpoints = [p.mountpoint for p in harddiskmanager.getMountedPartitions() if p.mountpoint != "/"]
+		self.mountpoints = [p.mountpoint for p in harddiskmanager.getMountedPartitions() if p.mountpoint != sep]
 		self.mountpoints.sort(key=lambda x: -len(x))
 
 	def checkChangedMountpoints(self):
@@ -1707,13 +1905,13 @@ class ConfigLocations(ConfigElement):
 				self.addedMount(x)
 
 	def getMountpoint(self, file):
-		file = os.path.realpath(file) + "/"
+		file = os_path.realpath(file) + sep
 		for m in self.mountpoints:
 			if file.startswith(m):
 				return m
 		return None
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		count = len(self.value) - 1
 		if key == ACTIONKEY_FIRST:
 			self.item = 0
@@ -1723,6 +1921,7 @@ class ConfigLocations(ConfigElement):
 			self.item = self.item + 1 if self.item < count else 0
 		elif key == ACTIONKEY_LAST:
 			self.item = count
+		# don't call callback
 
 	def getText(self):
 		return " ".join(self.value)
@@ -1731,9 +1930,9 @@ class ConfigLocations(ConfigElement):
 		if not selected:
 			valstr = " ".join(self.value)
 			if self.visible_width and len(valstr) > self.visible_width:
-				return ("text", valstr[0:self.visible_width])
+				return "text", valstr[0:self.visible_width]
 			else:
-				return ("text", valstr)
+				return "text", valstr
 		else:
 			i = 0
 			valstr = ""
@@ -1747,13 +1946,13 @@ class ConfigLocations(ConfigElement):
 					ind2 = len(valstr)
 				i += 1
 			if self.visible_width and len(valstr) > self.visible_width:
-				if ind1 + 1 < self.visible_width / 2:
+				if ind1 + 1 < self.visible_width // 2:
 					off = 0
 				else:
-					off = min(ind1 + 1 - self.visible_width / 2, len(valstr) - self.visible_width)
-				return ("mtext", valstr[off:off + self.visible_width], list(range(ind1 - off, ind2 - off)))
+					off = min(ind1 + 1 - self.visible_width // 2, len(valstr) - self.visible_width)
+				return "mtext", valstr[off:off + self.visible_width], list(range(ind1 - off, ind2 - off))
 			else:
-				return ("mtext", valstr, list(range(ind1, ind2)))
+				return "mtext", valstr, list(range(ind1, ind2))
 
 	def onDeselect(self, session):
 		self.pos = -1
@@ -1797,21 +1996,21 @@ class ConfigSubList(list):
 		list.__init__(self)
 		self.stored_values = {}
 
-	def save(self):
-		for x in self:
-			x.save()
-
 	def load(self):
-		for x in self:
-			x.load()
+		for item in self:
+			item.load()
+
+	def save(self):
+		for item in self:
+			item.save()
 
 	def getSavedValue(self):
-		res = {}
-		for i, val in enumerate(self):
-			sv = val.saved_value
-			if sv is not None:
-				res[str(i)] = sv
-		return res
+		values = {}
+		for index, val in enumerate(self):
+			saved = val.saved_value
+			if saved is not None:
+				values[str(index)] = saved
+		return values
 
 	def setSavedValue(self, values):
 		self.stored_values = dict(values)
@@ -1822,19 +2021,17 @@ class ConfigSubList(list):
 	saved_value = property(getSavedValue, setSavedValue)
 
 	def append(self, item):
-		i = str(len(self))
+		index = str(len(self))
 		list.append(self, item)
-		if i in self.stored_values:
-			item.saved_value = self.stored_values[i]
+		if index in self.stored_values:
+			item.saved_value = self.stored_values[index]
 			item.load()
 
 	def dict(self):
 		return dict([(str(index), value) for index, value in enumerate(self)])
 
-# same as ConfigSubList, just as a dictionary.
-# care must be taken that the 'key' has a proper
-# str() method, because it will be used in the config
-# file.
+# Same as ConfigSubList, just as a dictionary.
+# Care must be taken that the 'key' has a proper str() method, because it will be used in the config file.
 
 
 class ConfigSubDict(dict):
@@ -1842,21 +2039,21 @@ class ConfigSubDict(dict):
 		dict.__init__(self)
 		self.stored_values = {}
 
-	def save(self):
-		for x in self.values():
-			x.save()
-
 	def load(self):
-		for x in self.values():
-			x.load()
+		for item in self.values():
+			item.load()
+
+	def save(self):
+		for item in self.values():
+			item.save()
 
 	def getSavedValue(self):
-		res = {}
+		values = {}
 		for (key, val) in self.items():
-			sv = val.saved_value
-			if sv is not None:
-				res[str(key)] = sv
-		return res
+			saved = val.saved_value
+			if saved is not None:
+				values[str(key)] = saved
+		return values
 
 	def setSavedValue(self, values):
 		self.stored_values = dict(values)
@@ -1900,10 +2097,10 @@ class ConfigSubsection:
 		assert isinstance(value, (ConfigSubsection, ConfigElement, ConfigSubList, ConfigSubDict)), "ConfigSubsections can only store ConfigSubsections, ConfigSubLists, ConfigSubDicts or ConfigElements"
 		content = self.content
 		content.items[name] = value
-		x = content.stored_values.get(name, None)
-		if x is not None:
-			# print "ok, now we have a new item,", name, "and have the following value for it:", x
-			value.saved_value = x
+		val = content.stored_values.get(name, None)
+		if val is not None:
+			# print(f"[Config] Ok, now we have a new item '{name}' and have the following value for it '{str(val)}'.")
+			value.saved_value = val
 			value.load()
 
 	def __getattr__(self, name):
@@ -1912,14 +2109,14 @@ class ConfigSubsection:
 		raise AttributeError(name)
 
 	def getSavedValue(self):
-		res = self.content.stored_values
+		values = self.content.stored_values
 		for (key, val) in self.content.items.items():
-			sv = val.saved_value
-			if sv is not None:
-				res[key] = sv
-			elif key in res:
-				del res[key]
-		return res
+			saved = val.saved_value
+			if saved is not None:
+				values[key] = saved
+			elif key in values:
+				del values[key]
+		return values
 
 	def setSavedValue(self, values):
 		values = dict(values)
@@ -1932,23 +2129,24 @@ class ConfigSubsection:
 	saved_value = property(getSavedValue, setSavedValue)
 
 	def save(self):
-		for x in self.content.items.values():
-			x.save()
+		for item in self.content.items.values():
+			item.save()
 
 	def load(self):
-		for x in self.content.items.values():
-			x.load()
+		for item in self.content.items.values():
+			item.load()
+
+	def cancel(self):
+		for item in self.content.items.values():
+			item.cancel()
 
 	def dict(self):
 		return self.content.items
 
-# the root config object, which also can "pickle" (=serialize)
-# down the whole config tree.
+# The root config object, which also can "pickle" (=serialize) down the whole config tree.
 #
-# we try to keep non-existing config entries, to apply them whenever
-# a new config entry is added to a subsection
-# also, non-existing config entries will be saved, so they won't be
-# lost when a config entry disappears.
+# We try to keep non-existing config entries, to apply them whenever a new config entry is added to a subsection
+# Also, non-existing config entries will be saved, so they won't be lost when a config entry disappears.
 
 
 class Config(ConfigSubsection):
@@ -1961,9 +2159,9 @@ class Config(ConfigSubsection):
 			if isinstance(val, dict):
 				self.pickle_this(name, val, result)
 			elif isinstance(val, tuple):
-				result += [name, '=', val[0], '\n']
+				result += [name, '=', str(val[0]), '\n']
 			else:
-				result += [name, '=', val, '\n']
+				result += [name, '=', str(val), '\n']
 
 	def pickle(self):
 		result = []
@@ -1973,11 +2171,11 @@ class Config(ConfigSubsection):
 	def unpickle(self, lines, base_file=True):
 		tree = {}
 		configbase = tree.setdefault("config", {})
-		for l in lines:
-			if not l or l[0] == '#':
+		for element in lines:
+			if not element or element[0] == '#':
 				continue
 
-			result = l.split('=', 1)
+			result = element.split('=', 1)
 			if len(result) != 2:
 				continue
 			(name, val) = result
@@ -2008,28 +2206,31 @@ class Config(ConfigSubsection):
 	def saveToFile(self, filename):
 		text = self.pickle()
 		try:
-			import os
-			f = open(filename + ".writing", "w", encoding="UTF-8")
-			f.write(text)
-			f.flush()
-			os.fsync(f.fileno())
-			f.close()
-			os.rename(filename + ".writing", filename)
-		except IOError:
-			print("Config: Couldn't write %s" % filename)
+			with open(filename + ".writing", "w", encoding="UTF-8") as f:
+				f.write(text)
+				f.flush()
+				fsync(f.fileno())
+			rename(filename + ".writing", filename)
+		except OSError:
+			print("[Config] Couldn't write %s" % filename)
 
 	def loadFromFile(self, filename, base_file=True):
-		self.unpickle(open(filename, "r", encoding="UTF-8"), base_file)
+		with open(filename, "r", encoding="UTF-8") as f:
+			self.unpickle(f, base_file)
 
 
 class ConfigFile:
+	def __init__(self):
+		pass
+
 	CONFIG_FILE = resolveFilename(SCOPE_CONFIG, "settings")
 
 	def load(self):
 		try:
 			config.loadFromFile(self.CONFIG_FILE, True)
-		except IOError as e:
-			print("unable to load config (%s), assuming defaults..." % str(e))
+			print("[Config] Config file loaded ok...")
+		except OSError as error:
+			print("[Config] unable to load config (%s), assuming defaults..." % str(error))
 
 	def save(self):
 		# config.save()
@@ -2049,9 +2250,9 @@ class ConfigFile:
 		if len(names) > 1:
 			if names[0] == "config":
 				ret = self.__resolveValue(names[1:], config.content.items)
-				if ret and len(ret) or ret == "":
+				if ret and len(ret):
 					return ret
-		print("getResolvedKey", key, "failed !! (Typo??)")
+		# print("[Config] getResolvedKey", key, "empty variable.")
 		return ""
 
 
@@ -2074,8 +2275,8 @@ configfile.load()
 # config.arg = ConfigSubDict()
 # config.arg["Hello"] = ConfigYesNo()
 #
-# config.arg["Hello"].handleKey(KEY_RIGHT)
-# config.arg["Hello"].handleKey(KEY_RIGHT)
+# config.arg["Hello"].handleKey(ACTIONKEY_RIGHT)
+# config.arg["Hello"].handleKey(ACTIONKEY_RIGHT)
 #
 # #config.saved_value
 #
@@ -2094,7 +2295,15 @@ class ConfigCECAddress(ConfigSequence):
 		self.overwrite = True
 		self.auto_jump = auto_jump
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
+		prev = str(self.value)
+		self.execHandleKey(key)
+		if prev != str(self.value):
+			self.changed()
+			if callable(callback):
+				callback()
+
+	def execHandleKey(self, key):
 		if key == ACTIONKEY_LEFT:
 			if self.marked_block > 0:
 				self.marked_block -= 1
@@ -2125,35 +2334,35 @@ class ConfigCECAddress(ConfigSequence):
 				oldvalue *= 10
 				newvalue = oldvalue + number
 				if self.auto_jump and newvalue > self.limits[self.marked_block][1] and self.marked_block < len(self.limits) - 1:
-					self.handleKey(ACTIONKEY_RIGHT)
-					self.handleKey(key)
+					self.execHandleKey(ACTIONKEY_RIGHT)
+					self.execHandleKey(key)
 					return
 				else:
 					self._value[self.marked_block] = newvalue
 			if len(str(self._value[self.marked_block])) >= self.blockLen[self.marked_block]:
-				self.handleKey(ACTIONKEY_RIGHT)
+				self.execHandleKey(ACTIONKEY_RIGHT)
 			self.validate()
-			self.changed()
 
 	def genText(self):
 		value = ""
 		block_strlen = []
-		for i in self._value:
-			block_strlen.append(len(str(i)))
-			if value:
-				value += self.seperator
-			value += str(i)
-		leftPos = sum(block_strlen[:(self.marked_block)]) + self.marked_block
+		if self._value:
+			for i in self._value:
+				block_strlen.append(len(str(i)))
+				if value:
+					value += self.seperator
+				value += str(i)
+		leftPos = sum(block_strlen[:self.marked_block]) + self.marked_block
 		rightPos = sum(block_strlen[:(self.marked_block + 1)]) + self.marked_block
 		mBlock = list(range(leftPos, rightPos))
-		return (value, mBlock)
+		return value, mBlock
 
 	def getMulti(self, selected):
 		(value, mBlock) = self.genText()
 		if self.enabled:
-			return ("mtext"[1 - selected:], value, mBlock)
+			return "mtext"[1 - selected:], value, mBlock
 		else:
-			return ("text", value)
+			return "text", value
 
 	def getHTML(self, id=0):
 		# I do not know why id is here but it is used in the sources renderer and I'm afraid we should keep it for compatibily. It is not used here but I give at a default value
@@ -2168,7 +2377,7 @@ class ConfigAction(ConfigElement):
 		self.action = action
 		self.actionargs = args
 
-	def handleKey(self, key):
+	def handleKey(self, key, callback=None):
 		if (key == ACTIONKEY_SELECT):
 			self.action(*self.actionargs)
 

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpg.py
@@ -72,6 +72,7 @@ config.misc.graph_mepg.event_alignment = ConfigSelection(default=possibleAlignme
 config.misc.graph_mepg.show_timelines = ConfigSelection(default="all", choices=[("nothing", _("no")), ("all", _("all")), ("now", _("actual time only"))])
 config.misc.graph_mepg.servicename_alignment = ConfigSelection(default=possibleAlignmentChoices[0][0], choices=possibleAlignmentChoices)
 config.misc.graph_mepg.extension_menu = ConfigYesNo(default=False)
+config.misc.graph_mepg.extension_menu.addNotifier(plugins.reloadPlugins, initial_call=False, immediate_feedback=False)
 config.misc.graph_mepg.show_record_clocks = ConfigYesNo(default=True)
 config.misc.graph_mepg.show_disabled_timers= ConfigYesNo(default=False)
 config.misc.graph_mepg.zap_blind_bouquets = ConfigYesNo(default=False)

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/GraphMultiEpgSetup.py
@@ -1,64 +1,6 @@
-# -*- coding: utf-8 -*-
-from Screens.Screen import Screen
-from Components.ActionMap import ActionMap
-from Components.Pixmap import Pixmap
-from Components.Label import Label
-from Components.PluginComponent import plugins
-from Components.config import config
-from Components.ConfigList import ConfigListScreen
-
-addnotifier = None
+from Screens.Setup import Setup
 
 
-class GraphMultiEpgSetup(ConfigListScreen, Screen):
-	skin = """
-		<screen name="GraphMultiEPGSetup" position="center,center" size="560,490" title="Electronic Program Guide Setup">
-			<ePixmap pixmap="buttons/red.png" position="0,0" size="140,40" alphaTest="on" />
-			<ePixmap pixmap="buttons/green.png" position="140,0" size="140,40" alphaTest="on" />
-			<widget name="key_red" position="0,0" zPosition="1" size="140,40" font="Regular;20" horizontalAlignment="center" verticalAlignment="center" backgroundColor="#9f1313" transparent="1" />
-			<widget name="key_green" position="140,0" zPosition="1" size="140,40" font="Regular;20" horizontalAlignment="center" verticalAlignment="center" backgroundColor="#1f771f" transparent="1" />
-			<widget name="config" position="10,50" size="550,430" />
-		</screen>"""
-
+class GraphMultiEpgSetup(Setup):
 	def __init__(self, session, args=None):
-		Screen.__init__(self, session)
-		self.setTitle(_("GraphMultiEpg Settings"))
-		self.skinName = ["GraphMultiEpgSetup", "Setup"]
-
-		self["key_red"] = Label(_("Cancel"))
-		self["key_green"] = Label(_("Save"))
-
-		self["actions"] = ActionMap(["SetupActions", "MenuActions", "ColorActions"],
-		{
-			"ok": self.keySave,
-			"save": self.keySave,
-			"green": self.keySave,
-			"cancel": self.keyCancel,
-			"red": self.keyCancel,
-			"menu": self.closeRecursive,
-		}, -1)
-
-		global addnotifier
-		self.list = []
-		self.list.append((_("Event font size (relative to skin size)"), config.misc.graph_mepg.ev_fontsize))
-		self.list.append((_("Time scale"), config.misc.graph_mepg.prev_time_period))
-		self.list.append((_("Prime time"), config.misc.graph_mepg.prime_time))
-		self.list.append((_("Items per page "), config.misc.graph_mepg.items_per_page))
-		self.list.append((_("Items per page for list screen"), config.misc.graph_mepg.items_per_page_listscreen))
-		self.list.append((_("Start with list screen"), config.misc.graph_mepg.default_mode))
-		self.list.append((_("Skip empty services"), config.misc.graph_mepg.overjump))
-		self.list.append((_("Service title mode"), config.misc.graph_mepg.servicetitle_mode))
-		self.list.append((_("Round start time on"), config.misc.graph_mepg.roundTo))
-		self.list.append((_("Function of OK button"), config.misc.graph_mepg.OKButton))
-		self.list.append((_("Alignment of service names"), config.misc.graph_mepg.servicename_alignment))
-		self.list.append((_("Alignment of events"), config.misc.graph_mepg.event_alignment))
-		self.list.append((_("Show vertical timelines"), config.misc.graph_mepg.show_timelines))
-		self.list.append((_("Center time-labels and remove date"), config.misc.graph_mepg.center_timeline))
-		self.list.append((_("Show in extensions menu"), config.misc.graph_mepg.extension_menu))
-		self.list.append((_("Show record clock icons"), config.misc.graph_mepg.show_record_clocks))
-		self.list.append((_("Show disabled timers (local only)"), config.misc.graph_mepg.show_disabled_timers))
-		self.list.append((_("Zap bouquets blindly on zap buttons"), config.misc.graph_mepg.zap_blind_bouquets))
-		if addnotifier is None:
-			addnotifier = config.misc.graph_mepg.extension_menu.addNotifier(plugins.reloadPlugins, initial_call=False)
-
-		ConfigListScreen.__init__(self, self.list, session)
+		Setup.__init__(self, session, "graphmultiepgsetup", plugin="Extensions/GraphMultiEPG")

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/Makefile.am
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/Makefile.am
@@ -8,4 +8,4 @@ install_PYTHON =	\
 	GraphMultiEpg.py \
 	GraphMultiEpgSetup.py
 
-
+install_DATA = setup.xml

--- a/lib/python/Plugins/Extensions/GraphMultiEPG/setup.xml
+++ b/lib/python/Plugins/Extensions/GraphMultiEPG/setup.xml
@@ -1,0 +1,23 @@
+<!--suppress XmlUnboundNsPrefix -->
+<setupxml>
+    <setup key="graphmultiepgsetup" title="GraphMultiEpg Settings">
+        <item text="Event font size (relative to skin size)">config.misc.graph_mepg.ev_fontsize</item>
+        <item text="Time scale">config.misc.graph_mepg.prev_time_period</item>
+        <item text="Prime time">config.misc.graph_mepg.prime_time</item>
+        <item text="Items per page">config.misc.graph_mepg.items_per_page</item>
+        <item text="Items per page for list screen">config.misc.graph_mepg.items_per_page_listscreen</item>
+        <item text="Start with list screen">config.misc.graph_mepg.default_mode</item>
+        <item text="Skip empty services">config.misc.graph_mepg.overjump</item>
+        <item text="Service title mode">config.misc.graph_mepg.servicetitle_mode</item>
+        <item text="Round start time on">config.misc.graph_mepg.roundTo</item>
+        <item text="Function of OK button">config.misc.graph_mepg.OKButton</item>
+        <item text="Alignment of service names">config.misc.graph_mepg.servicename_alignment</item>
+        <item text="Alignment of events">config.misc.graph_mepg.event_alignment</item>
+        <item text="Show vertical timelines">config.misc.graph_mepg.show_timelines</item>
+        <item text="Center time-labels and remove date">config.misc.graph_mepg.center_timeline</item>
+        <item text="Show in extensions menu">config.misc.graph_mepg.extension_menu</item>
+        <item text="Show record clock icons">config.misc.graph_mepg.show_record_clocks</item>
+        <item text="Show disabled timers (local only)">config.misc.graph_mepg.show_disabled_timers</item>
+        <item text="Zap bouquets blindly on zap buttons">config.misc.graph_mepg.zap_blind_bouquets</item>
+    </setup>
+</setupxml>

--- a/lib/python/Plugins/Extensions/MediaPlayer/settings.py
+++ b/lib/python/Plugins/Extensions/MediaPlayer/settings.py
@@ -62,19 +62,13 @@ class MediaPlayerSettings(ConfigListScreen, Screen):
 		self.skinName = ["MediaPlayerSettings", "Setup"]
 		self.setTitle(_("Edit settings"))
 
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-
-		ConfigListScreen.__init__(self, [], session)
+		ConfigListScreen.__init__(self, [], session, fullUI=True)
 		self.parent = parent
 		self.initConfigList()
 		config.mediaplayer.saveDirOnExit.addNotifier(self.initConfigList)
 
-		self["setupActions"] = ActionMap(["SetupActions", "ColorActions"],
+		self["setupActions"] = ActionMap(["SetupActions"],
 		{
-			"green": self.keySave,
-			"red": self.keyCancel,
-			"cancel": self.keyCancel,
 			"ok": self.ok,
 		}, -2)
 

--- a/lib/python/Plugins/Extensions/PicturePlayer/ui.py
+++ b/lib/python/Plugins/Extensions/PicturePlayer/ui.py
@@ -147,15 +147,6 @@ class Pic_Setup(ConfigListScreen, Screen):
 		# for the skin: first try MediaPlayerSettings, then Setup, this allows individual skinning
 		self.skinName = ["PicturePlayerSetup", "Setup"]
 		self.setTitle(_("Settings"))
-		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-				"ok": self.keySave,
-				"menu": self.closeRecursive,
-			}, -2)
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
 
 		setup_list = [
 			(_("Slide show interval (sec.)"), config.pic.slidetime),
@@ -170,7 +161,7 @@ class Pic_Setup(ConfigListScreen, Screen):
 			(_("Auto EXIF Orientation rotation/flipping"), config.pic.autoOrientation),
 			(_("Stop play TV"), config.pic.stopPlayTv),
 		]
-		ConfigListScreen.__init__(self, setup_list, session)
+		ConfigListScreen.__init__(self, setup_list, session, fullUI=True)
 
 
 class Pic_Exif(Screen):

--- a/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/DiseqcTester/plugin.py
@@ -510,16 +510,10 @@ class DiseqcTesterTestTypeSelection(ConfigListScreen, Screen):
 		self.setTitle(_("DiSEqC-tester settings"))
 		self.feid = feid
 
-		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
+		self["actions"] = ActionMap(["SetupActions"],
 			{
-				"cancel": self.keyCancel,
-				"save": self.keyOK,
-				"ok": self.keyOK,
 				"menu": self.closeRecursive,
 			}, -2)
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
 
 		self.list = []
 
@@ -539,9 +533,9 @@ class DiseqcTesterTestTypeSelection(ConfigListScreen, Screen):
 		self.logEntry = (_("Log results to /tmp"), self.log)
 		self.list.append(self.logEntry)
 
-		ConfigListScreen.__init__(self, self.list, session)
+		ConfigListScreen.__init__(self, self.list, session, fullUI=True)
 
-	def keyOK(self):
+	def keySave(self):
 		print(self.testtype.getValue())
 		testtype = DiseqcTester.TEST_TYPE_QUICK
 		if self.testtype.getValue() == "quick":
@@ -551,9 +545,6 @@ class DiseqcTesterTestTypeSelection(ConfigListScreen, Screen):
 		elif self.testtype.getValue() == "complete":
 			testtype = DiseqcTester.TEST_TYPE_COMPLETE
 		self.session.open(DiseqcTester, feid=self.feid, test_type=testtype, loopsfailed=int(self.loopsfailed.value), loopssuccessful=int(self.loopssuccessful.value), log=self.log.value)
-
-	def keyCancel(self):
-		self.close()
 
 
 class DiseqcTesterNimSelection(NimSelection):

--- a/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/FastScan/plugin.py
@@ -159,14 +159,6 @@ class FastScanScreen(ConfigListScreen, Screen):
 
 		self.setTitle(_("FastScan"))
 
-		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
-		{
-			"ok": self.keyGo,
-			"save": self.keySave,
-			"cancel": self.keyCancel,
-			"menu": self.closeRecursive,
-		}, -2)
-
 		lastConfiguration = eval(config.misc.fastscan.last_configuration.value)
 
 		def providerChanged(configEntry):
@@ -197,12 +189,10 @@ class FastScanScreen(ConfigListScreen, Screen):
 		for provider in providers:
 			self.config_autoproviders[provider[0]] = ConfigYesNo(default=provider[0] in auto_providers)
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session, self.createSetup)
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.createSetup, fullUI=True)
 		self.createSetup()
 		self.finished_cb = None
 		self["introduction"] = Label(_("Select your provider, and press OK to start the scan"))
-		self["key_red"] = Label(_("Cancel"))
-		self["key_green"] = Label(_("Save"))
 
 	def createSetup(self):
 		self.list = []
@@ -240,8 +230,9 @@ class FastScanScreen(ConfigListScreen, Screen):
 		self.saveConfiguration()
 		self.close()
 
-	def keyGo(self):
-		if self.scan_provider.value:
+	def keyMenuCallback(self, answer):
+		ConfigListScreen.keyMenuCallback(self, answer)
+		if answer and self.scan_provider.value and self.getCurrentEntry() == _("Provider"):
 			self.saveConfiguration()
 			self.startScan()
 
@@ -272,9 +263,6 @@ class FastScanScreen(ConfigListScreen, Screen):
 				transponderParameters=self.getTransponderParameters(parameters[0]),
 				scanPid=pid, keepNumbers=self.scan_keepnumbering.value, keepSettings=self.scan_keepsettings.value, createRadioBouquet=self.scan_create_radio_bouquet.value,
 				providerName=self.scan_provider.getText())
-
-	def keyCancel(self):
-		self.close()
 
 
 class FastScanAutoScreen(FastScanScreen):

--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -114,7 +114,7 @@ def main(session, **kwargs):
 
 def startSetup(menuid):
 	# only show in the menu when set to intermediate or higher
-	if menuid == "video" and config.av.videoport.value == "DVI" and config.usage.setup_level.index >= 1:
+	if menuid == "video" and config.av.videoport.value == "HDMI" and config.usage.setup_level.index >= 1:
 		return [(_("HDMI-CEC setup"), main, "hdmi_cec_setup", 0)]
 	return []
 

--- a/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/HdmiCEC/plugin.py
@@ -1,9 +1,16 @@
-# -*- coding: utf-8 -*-
-from Screens.Screen import Screen
+from os import path
+
+import Components.HdmiCec
+from Components.ActionMap import ActionMap
+from Components.Button import Button
 from Components.ConfigList import ConfigListScreen
 from Components.config import config
 from Components.Label import Label
 from Components.Sources.StaticText import StaticText
+from Plugins.Plugin import PluginDescriptor
+from Screens.LocationBox import LocationBox
+from Screens.Screen import Screen
+
 
 
 class HdmiCECSetupScreen(ConfigListScreen, Screen):
@@ -12,30 +19,19 @@ class HdmiCECSetupScreen(ConfigListScreen, Screen):
 		self.skinName = "Setup"
 		self.setTitle(_("HDMI-CEC setup"))
 
-		from Components.ActionMap import ActionMap
-		from Components.Button import Button
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
 		self["key_yellow"] = StaticText(_("Set fixed"))
 		self["key_blue"] = StaticText(_("Clear fixed"))
 		self["description"] = Label("")
 
-		self["actions"] = ActionMap(["SetupActions", "ColorActions", "MenuActions"],
+		self["actions"] = ActionMap(["ColorActions"],
 		{
-			"ok": self.keyOk,
-			"save": self.keyGo,
-			"cancel": self.keyCancel,
-			"green": self.keyGo,
-			"red": self.keyCancel,
 			"yellow": self.setFixedAddress,
 			"blue": self.clearFixedAddress,
-			"menu": self.closeRecursive,
 		}, -2)
 
 		self.list = []
 		self.logpath_entry = None
-		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.createSetup)
+		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.createSetup, fullUI=True)
 		self.createSetup()
 		self.updateAddress()
 
@@ -73,33 +69,25 @@ class HdmiCECSetupScreen(ConfigListScreen, Screen):
 		self["config"].list = self.list
 
 	def getCurrentDescription(self):
-		description = self["config"].getCurrent()[2] if len(self["config"].getCurrent()) > 2 else ""
+		description = ConfigListScreen.getCurrentDescription(self)
 		return "%s\n%s\n\n%s" % (self.current_address, self.fixed_address, description) if config.hdmicec.enabled.value else description
 
-	def keyGo(self):
-		for x in self["config"].list:
-			x[1].save()
-		self.close()
-
-	def keyOk(self):
+	def keySelect(self):
 		currentry = self["config"].getCurrent()
 		if currentry == self.logpath_entry:
 			self.set_path()
 		else:
-			self.keyGo()
+			ConfigListScreen.keySelect(self)
 
 	def setFixedAddress(self):
-		import Components.HdmiCec
 		Components.HdmiCec.hdmi_cec.setFixedPhysicalAddress(Components.HdmiCec.hdmi_cec.getPhysicalAddress())
 		self.updateAddress()
 
 	def clearFixedAddress(self):
-		import Components.HdmiCec
 		Components.HdmiCec.hdmi_cec.setFixedPhysicalAddress("0.0.0.0")
 		self.updateAddress()
 
 	def updateAddress(self):
-		import Components.HdmiCec
 		self.current_address = _("Current CEC address") + ":\t" + Components.HdmiCec.hdmi_cec.getPhysicalAddress()
 		if config.hdmicec.fixed_physical_address.value == "0.0.0.0":
 			self.fixed_address = _("Press yellow button to set CEC address again")
@@ -113,7 +101,6 @@ class HdmiCECSetupScreen(ConfigListScreen, Screen):
 
 	def set_path(self):
 		inhibitDirs = ["/autofs", "/bin", "/boot", "/dev", "/etc", "/lib", "/proc", "/sbin", "/sys", "/tmp", "/usr"]
-		from Screens.LocationBox import LocationBox
 		txt = _("Select directory for logfile")
 		self.session.openWithCallback(self.logPath, LocationBox, text=txt, currDir=config.hdmicec.log_path.value,
 				bookmarks=config.hdmicec.bookmarks, autoAdd=False, editDir=True,
@@ -127,15 +114,12 @@ def main(session, **kwargs):
 
 def startSetup(menuid):
 	# only show in the menu when set to intermediate or higher
-	if menuid == "video" and config.av.videoport.value == "HDMI" and config.usage.setup_level.index >= 1:
+	if menuid == "video" and config.av.videoport.value == "DVI" and config.usage.setup_level.index >= 1:
 		return [(_("HDMI-CEC setup"), main, "hdmi_cec_setup", 0)]
 	return []
 
 
 def Plugins(**kwargs):
-	from os import path
 	if path.exists("/dev/hdmi_cec") or path.exists("/dev/misc/hdmi_cec0"):
-		import Components.HdmiCec
-		from Plugins.Plugin import PluginDescriptor
 		return [PluginDescriptor(where=PluginDescriptor.WHERE_MENU, fnc=startSetup)]
 	return []

--- a/lib/python/Plugins/SystemPlugins/SatelliteEquipmentControl/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/SatelliteEquipmentControl/plugin.py
@@ -19,14 +19,9 @@ class SecParameterSetup(ConfigListScreen, Screen):
 		self["key_green"] = StaticText(_("OK"))
 		self["key_blue"] = StaticText(_("Restore defaults"))
 
-		self["actions"] = ActionMap(["SetupActions", "MenuActions", "ColorActions"],
+		self["actions"] = ActionMap(["ColorActions"],
 		{
-			"ok": self.keySave,
-			"green": self.keySave,
-			"cancel": self.keyCancel,
-			"red": self.keyCancel,
 			"blue": self.resetDefaults,
-			"menu": self.closeRecursive,
 		}, -2)
 
 		self.secList = [
@@ -51,7 +46,7 @@ class SecParameterSetup(ConfigListScreen, Screen):
 			(_("Unicable delay after enable voltage before switch command"), config.sec.unicable_delay_after_enable_voltage_before_switch_command),
 			(_("Unicable delay after change voltage before switch command"), config.sec.unicable_delay_after_change_voltage_before_switch_command),
 			(_("Unicable delay after last diseqc command"), config.sec.unicable_delay_after_last_diseqc_command)]
-		ConfigListScreen.__init__(self, [])
+		ConfigListScreen.__init__(self, [], fullUI=True)
 		self.createSetup()
 
 	def createSetup(self):

--- a/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancement/plugin.py
@@ -162,12 +162,6 @@ class VideoEnhancementSetup(ConfigListScreen, Screen):
 		self.keyYellowConfirm(True)
 		self.close()
 
-	def keyCancel(self):
-		if self["config"].isChanged():
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
-		else:
-			self.close()
-
 	def keyYellowConfirm(self, confirmed):
 		if confirmed:
 			if self.contrastEntry is not None:
@@ -355,10 +349,6 @@ class VideoEnhancementPreview(ConfigListScreen, Screen):
 
 	def getCurrentValue(self):
 		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 
 def videoEnhancementSetupMain(session, **kwargs):

--- a/lib/python/Plugins/SystemPlugins/VideoEnhancementAML/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/VideoEnhancementAML/plugin.py
@@ -129,12 +129,6 @@ class VideoEnhancementSetup(Screen, ConfigListScreen):
 		self.keyYellowConfirm(True)
 		self.close()
 
-	def keyCancel(self):
-		if self["config"].isChanged():
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), default=False)
-		else:
-			self.close()
-
 	def keyYellowConfirm(self, confirmed):
 		if not confirmed:
 			print("not confirmed")
@@ -195,10 +189,6 @@ class VideoEnhancementSetup(Screen, ConfigListScreen):
 
 	def getCurrentValue(self):
 		return str(self["config"].getCurrent()[1].getText())
-
-	def createSummary(self):
-		from Screens.Setup import SetupSummary
-		return SetupSummary
 
 
 class VideoEnhancementPreview(Screen, ConfigListScreen):

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from Screens.Screen import Screen
+from Screens.Setup import Setup
 import Screens.InfoBar
 from Screens.ScreenSaver import InfoBarScreenSaver
 import Components.ParentalControl
 from Components.Button import Button
-from Components.ConfigList import ConfigListScreen
 from Components.Label import Label
 from Components.Sources.Boolean import Boolean
 from Components.Pixmap import Pixmap
@@ -59,29 +59,10 @@ FLAG_IS_DEDICATED_3D = 128
 FLAG_CENTER_DVB_SUBS = 2048 #define in lib/dvb/idvb.h as dxNewFound = 64 and dxIsDedicated3D = 128
 
 
-class InsertService(ConfigListScreen, Screen):
+class InsertService(Setup):
 	def __init__(self, session):
-		Screen.__init__(self, session)
-		self.skinName = ["Setup"]
-		ConfigListScreen.__init__(self, [], session=session, on_change=self.changedEntry)
-
-		self["actions2"] = ActionMap(["SetupActions"],
-		{
-			"ok": self.run,
-			"cancel": boundFunction(self.close, None),
-			"save": self.run,
-		}, -2)
-
-		self["key_red"] = StaticText(_("Exit"))
-		self["key_green"] = StaticText(_("Save"))
-
-		self["description"] = Label("")
-		self["VKeyIcon"] = Boolean(False)
-		self["HelpWindow"] = Pixmap()
-		self["HelpWindow"].hide()
-
 		self.createConfig()
-		self.changedEntry()
+		Setup.__init__(self, session, None)
 
 	def createConfig(self):
 		choices = [("Select Service", _("Select Service"))]
@@ -94,6 +75,11 @@ class InsertService(ConfigListScreen, Screen):
 		self.servicename = ConfigText("default_name")
 
 	def createSetup(self):
+		if self.servicetype.value == "HDMI-in":
+			self.servicerefstring = '8192:0:1:0:0:0:0:0:0:0::%s' % self.servicename.value
+		else:
+			self.servicerefstring = '%s:0:1:0:0:0:0:0:0:0:%s:%s' % (self.streamtype.value, self.streamurl.value.replace(':', '%3a'), self.servicename.value)
+		self.title = '%s [%s]' % (_("Insert Service"), self.servicerefstring)
 		self.list = []
 		self.list.append((_("Service Type"), self.servicetype, _("Select service type")))
 		if self.servicetype.value != "Select Service":
@@ -104,18 +90,16 @@ class InsertService(ConfigListScreen, Screen):
 		self["config"].list = self.list
 
 	def changedEntry(self):
-		if self.servicetype.value == "HDMI-in":
-			self.servicerefstring = '8192:0:1:0:0:0:0:0:0:0::%s' % self.servicename.value
-		else:
-			self.servicerefstring = '%s:0:1:0:0:0:0:0:0:0:%s:%s' % (self.streamtype.value, self.streamurl.value.replace(':', '%3a'), self.servicename.value)
-		Screen.setTitle(self, '%s [%s]' % (_("Insert Service"), self.servicerefstring))
 		self.createSetup()
 
-	def run(self):
+	def keySave(self):
 		if self.servicetype.value == "Select Service":
 			self.session.openWithCallback(self.channelSelectionCallback, SimpleChannelSelection, _("Select channel"))
 		else:
 			self.close(eServiceReference(self.servicerefstring))
+
+	def keySelect(self):
+		self.keySave()
 
 	def channelSelectionCallback(self, *args):
 		if len(args):
@@ -462,7 +446,7 @@ class ChannelContextMenu(Screen):
 	def insertService(self):
 		self.session.openWithCallback(self.insertServiceCallback, InsertService)
 
-	def insertServiceCallback(self, answer):
+	def insertServiceCallback(self, answer=None):
 		if answer:
 			self.csel.insertService(answer)
 			self.close()

--- a/lib/python/Screens/Ci.py
+++ b/lib/python/Screens/Ci.py
@@ -556,17 +556,7 @@ class PermanentPinEntry(ConfigListScreen, Screen):
 		self.pin2.addEndNotifier(boundFunction(self.valueChanged, 2))
 		self.list.append((_("Enter PIN"), NoSave(self.pin1)))
 		self.list.append((_("Reenter PIN"), NoSave(self.pin2)))
-		ConfigListScreen.__init__(self, self.list)
-
-		self["actions"] = NumberActionMap(["DirectionActions", "ColorActions", "OkCancelActions"],
-		{
-			"cancel": self.cancel,
-			"red": self.cancel,
-			"save": self.keyOK,
-		}, -1)
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
+		ConfigListScreen.__init__(self, self.list, fullUI=True)
 
 	def valueChanged(self, pin, value):
 		if pin == 1:
@@ -574,7 +564,7 @@ class PermanentPinEntry(ConfigListScreen, Screen):
 		elif pin == 2:
 			self.keyOK()
 
-	def keyOK(self):
+	def keySave(self):
 		if self.pin1.value == self.pin2.value:
 			self.pin.value = self.pin1.value
 			self.pin.save()
@@ -582,5 +572,5 @@ class PermanentPinEntry(ConfigListScreen, Screen):
 		else:
 			self.session.open(MessageBox, _("The PIN codes you entered are different."), MessageBox.TYPE_ERROR)
 
-	def cancel(self):
+	def keyCancel(self):
 		self.close(None)

--- a/lib/python/Screens/Hotkey.py
+++ b/lib/python/Screens/Hotkey.py
@@ -807,12 +807,9 @@ class InfoBarHotkey:
 				from Screens.Menu import MainMenu, mdom
 				root = mdom.getroot()
 				for x in root.findall("menu"):
-					y = x.find("id")
-					if y is not None:
-						id = y.get("val")
-						if id and id == selected[1]:
-							menu_screen = self.session.open(MainMenu, x)
-							break
+					if x.get("key") == selected[1]:
+						menu_screen = self.session.open(MainMenu, x)
+						break
 
 	def showServiceListOrMovies(self):
 		if hasattr(self, "openServiceList"):

--- a/lib/python/Screens/InputDeviceSetup.py
+++ b/lib/python/Screens/InputDeviceSetup.py
@@ -203,8 +203,6 @@ class InputDeviceSetup(ConfigListScreen, Screen):
 		self.setTitle(_("Input device setup"))
 		self.inputDevice = device
 		iInputDevices.currentDevice = self.inputDevice
-		self.onChangedEntry = []
-		self.isStepSlider = None
 		self.enableEntry = None
 		self.repeatEntry = None
 		self.delayEntry = None
@@ -212,19 +210,8 @@ class InputDeviceSetup(ConfigListScreen, Screen):
 		self.enableConfigEntry = None
 
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.createSetup, fullUI=True)
 
-		self["actions"] = ActionMap(["SetupActions", "MenuActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.apply,
-				"menu": self.closeRecursive,
-			}, -2)
-
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
-		self["key_yellow"] = StaticText()
-		self["key_blue"] = StaticText()
 		self["introduction"] = StaticText()
 
 		self.createSetup()
@@ -241,18 +228,10 @@ class InputDeviceSetup(ConfigListScreen, Screen):
 
 	def createSetup(self):
 		self.list = []
-		label = _("Change repeat and delay settings?")
-		cmd = "self.enableEntry = (label, config.inputDevices." + self.inputDevice + ".enabled)"
-		exec(cmd)
-		label = _("Interval between keys when repeating:")
-		cmd = "self.repeatEntry = (label, config.inputDevices." + self.inputDevice + ".repeat)"
-		exec(cmd)
-		label = _("Delay before key repeat starts:")
-		cmd = "self.delayEntry = (label, config.inputDevices." + self.inputDevice + ".delay)"
-		exec(cmd)
-		label = _("Device name:")
-		cmd = "self.nameEntry = (label, config.inputDevices." + self.inputDevice + ".name)"
-		exec(cmd)
+		self.enableEntry = (_("Change repeat and delay settings?"), getattr(config.inputDevices, self.inputDevice).enabled)
+		self.repeatEntry = (_("Interval between keys when repeating:"), getattr(config.inputDevices, self.inputDevice).repeat)
+		self.delayEntry = (_("Delay before key repeat starts:"), getattr(config.inputDevices, self.inputDevice).delay)
+		self.nameEntry = (_("Device name:"), getattr(config.inputDevices, self.inputDevice).name)
 		if self.enableEntry:
 			if isinstance(self.enableEntry[1], ConfigYesNo):
 				self.enableConfigEntry = self.enableEntry[1]
@@ -301,30 +280,11 @@ class InputDeviceSetup(ConfigListScreen, Screen):
 			return
 		else:
 			self.nameEntry[1].setValue(iInputDevices.getDeviceAttribute(self.inputDevice, 'name'))
-			cmd = "config.inputDevices." + self.inputDevice + ".name.save()"
-			exec(cmd)
+			getattr(config.inputDevices, self.inputDevice).name.save()
 			self.keySave()
 
 	def apply(self):
 		self.session.openWithCallback(self.confirm, MessageBox, _("Use these input device settings?"), MessageBox.TYPE_YESNO, timeout=20, default=True)
-
-	def cancelConfirm(self, result):
-		if not result:
-			return
-		for x in self["config"].list:
-			x[1].cancel()
-		self.close()
-
-	def keyCancel(self):
-		if self["config"].isChanged():
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"), MessageBox.TYPE_YESNO, timeout=20, default=True)
-		else:
-			self.close()
-
-	def changedEntry(self):
-		for x in self.onChangedEntry:
-			x()
-		self.selectionChanged()
 
 
 class RemoteControlType(ConfigListScreen, Screen):

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -23,7 +23,7 @@ from os.path import exists
 
 import xml.etree.ElementTree
 
-from Screens.Setup import Setup, getSetupTitle
+from Screens.Setup import Setup
 from Components.NimManager import nimmanager  # nimmanager is used in eval(conditional), do not remove this import
 
 
@@ -159,7 +159,9 @@ class Menu(Screen, ProtectedScreen):
 	def openSetup(self, dialog):
 		self.session.openWithCallback(self.menuClosed, Setup, dialog)
 
-	def addMenu(self, destList, node, parent=None):
+	def addMenu(self, destList, node):
+		if not (key := node.get("key")):
+			return
 		requires = node.get("requires")
 		if requires:
 			if requires[0] == '!':
@@ -167,19 +169,20 @@ class Menu(Screen, ProtectedScreen):
 					return
 			elif not SystemInfo.get(requires, False):
 				return
-		MenuTitle = _(node.get("text", "??"))
-		entryID = node.get("entryID", "undefined")
+		conditional = node.get("conditional")
+		if conditional and not eval(conditional):
+			return
+		menu_text = _(x) if (x := node.get("text")) else "* fix me *"
 		weight = node.get("weight", 50)
-		description = node.get("description", "").encode("UTF-8") or None
-		description = description and _(description)
-		menupng = MenuEntryPixmap(entryID, self.png_cache)
+		description = _(x) if (x := node.get("description", "")) else None
+		menupng = MenuEntryPixmap(key, self.png_cache)
 		x = node.get("flushConfigOnClose")
 		if x:
 			a = boundFunction(self.session.openWithCallback, self.menuClosedWithConfigFlush, Menu, node)
 		else:
 			a = boundFunction(self.session.openWithCallback, self.menuClosed, Menu, node)
 		#TODO add check if !empty(node.childNodes)
-		destList.append((MenuTitle, a, entryID, weight, description, menupng))
+		destList.append((menu_text, a, key, weight, description, menupng))
 
 	def menuClosedWithConfigFlush(self, *res):
 		configfile.save()
@@ -195,7 +198,9 @@ class Menu(Screen, ProtectedScreen):
 		else:
 			self.createMenuList()
 
-	def addItem(self, destList, node, parent=None):
+	def addItem(self, destList, node):
+		if not (key := node.get("key")):
+			return
 		requires = node.get("requires")
 		if requires:
 			if requires[0] == '!':
@@ -206,12 +211,10 @@ class Menu(Screen, ProtectedScreen):
 		conditional = node.get("conditional")
 		if conditional and not eval(conditional):
 			return
-		item_text = node.get("text", "")
-		entryID = node.get("entryID", "undefined")
+		item_text = _(x) if (x := node.get("text")) else "* fix me *"
 		weight = node.get("weight", 50)
-		description = node.get("description", "").encode("UTF-8") or None
-		description = description and _(description)
-		menupng = MenuEntryPixmap(entryID, self.png_cache)
+		description = _(x) if (x := node.get("description", "")) else None
+		menupng = MenuEntryPixmap(key, self.png_cache)
 		for x in node:
 			if x.tag == 'screen':
 				module = x.get("module")
@@ -220,7 +223,6 @@ class Menu(Screen, ProtectedScreen):
 				if screen is None:
 					screen = module
 
-				# print module, screen
 				if module:
 					module = "Screens." + module
 				else:
@@ -231,20 +233,43 @@ class Menu(Screen, ProtectedScreen):
 				args = x.text or ""
 				screen += ", " + args
 
-				destList.append((_(item_text or "??"), boundFunction(self.runScreen, (module, screen)), entryID, weight, description, menupng))
+				destList.append((item_text, boundFunction(self.runScreen, (module, screen)), key, weight, description, menupng))
+				return
+			elif x.tag == 'plugin':
+				extensions = x.get("extensions")
+				system = x.get("system")
+				screen = x.get("screen")
+
+				if extensions:
+					module = extensions
+				elif system:
+					module = system
+
+				if screen is None:
+					screen = module
+
+				if extensions:
+					module = "Plugins.Extensions." + extensions + '.plugin'
+				elif system:
+					module = "Plugins.SystemPlugins." + system + '.plugin'
+				else:
+					module = ""
+
+				# check for arguments. they will be appended to the
+				# openDialog call
+				args = x.text or ""
+				screen += ", " + args
+
+				destList.append((item_text, boundFunction(self.runScreen, (module, screen)), key, weight, description, menupng))
 				return
 			elif x.tag == 'code':
-				destList.append((_(item_text or "??"), boundFunction(self.execText, x.text), entryID, weight, description, menupng))
+				destList.append((item_text, boundFunction(self.execText, x.text), key, weight, description, menupng))
 				return
 			elif x.tag == 'setup':
 				id = x.get("id")
-				if item_text == "":
-					item_text = _(getSetupTitle(id))
-				else:
-					item_text = _(item_text)
-				destList.append((item_text, boundFunction(self.openSetup, id), entryID, weight, description, menupng))
+				destList.append((item_text, boundFunction(self.openSetup, id), key, weight, description, menupng))
 				return
-		destList.append((item_text, self.nothing, entryID, weight, description, menupng))
+		destList.append((item_text, self.nothing, key, weight, description, menupng))
 
 	def sortByName(self, listentry):
 		return listentry[0].lower()
@@ -393,25 +418,16 @@ class Menu(Screen, ProtectedScreen):
 	def createMenuList(self, showNumericHelp=False):
 		self["key_blue"].text = _("Edit menu") if config.usage.menu_sort_mode.value == "user" else ""
 		self.list = []
-		self.menuID = None
-		parentEntryID = None
+		self.menuID = self.parentmenu.get("key")
 		for x in self.parentmenu: #walk through the actual nodelist
 			if not x.tag:
 				continue
-			parentEntryID = self.parentmenu.get("entryID", None)
 			if x.tag == 'item':
-				item_level = int(x.get("level", 0))
-				if item_level <= config.usage.setup_level.index:
-					self.addItem(self.list, x, parentEntryID)
-					count += 1
+				if int(x.get("level", 0)) <= config.usage.setup_level.index:
+					self.addItem(self.list, x)
 			elif x.tag == 'menu':
-				item_level = int(x.get("level", 0))
-				if item_level <= config.usage.setup_level.index:
-					self.addMenu(self.list, x, parentEntryID)
-					count += 1
-			elif x.tag == "id":
-				self.menuID = x.get("val")
-				count = 0
+				if int(x.get("level", 0)) <= config.usage.setup_level.index:
+					self.addMenu(self.list, x)
 
 		if self.menuID:
 			# plugins

--- a/lib/python/Screens/Menu.py
+++ b/lib/python/Screens/Menu.py
@@ -1,30 +1,34 @@
 # -*- coding: utf-8 -*-
-from Screens.Screen import Screen
 from xml.etree.ElementTree import parse
-from Screens.MessageBox import MessageBox
-from Screens.ParentalControlSetup import ProtectedScreen
-from Components.Sources.List import List
-from Components.ActionMap import NumberActionMap, ActionMap
-from Components.Sources.StaticText import StaticText
-from Components.config import configfile
-from Components.PluginComponent import plugins
-from Components.config import config, ConfigDictionarySet, NoSave
-from Components.SystemInfo import SystemInfo
-from Tools.BoundFunction import boundFunction
-from skin import parameters, menus, menuicons
-from Plugins.Plugin import PluginDescriptor
-from Tools.Directories import resolveFilename, SCOPE_SKIN, SCOPE_CURRENT_SKIN, SCOPE_GUISKIN, SCOPE_SKINS
-from Components.Button import Button
-from Tools.LoadPixmap import LoadPixmap
+
+from skin import findSkinScreen, menus, parameters, menus, menuicons
+from Components.config import ConfigDictionarySet, NoSave, config, configfile
 from Components.Pixmap import Pixmap
+from Components.PluginComponent import plugins
+from Components.Sources.List import List
+from Components.Sources.StaticText import StaticText
+from Components.ActionMap import NumberActionMap, ActionMap
+from Components.SystemInfo import SystemInfo
+from Components.Button import Button
+from Plugins.Plugin import PluginDescriptor
+from Screens.ParentalControlSetup import ProtectedScreen
+from Screens.Screen import Screen
+from Screens.Setup import Setup
+from Screens.MessageBox import MessageBox
+from Tools.BoundFunction import boundFunction
+from Tools.Directories import resolveFilename, SCOPE_CURRENT_SKIN, SCOPE_GUISKIN, SCOPE_SKINS
+from Tools.LoadPixmap import LoadPixmap
+
 from enigma import eTimer
-from skin import findSkinScreen
 from os.path import exists
 
-import xml.etree.ElementTree
-
-from Screens.Setup import Setup
 from Components.NimManager import nimmanager  # nimmanager is used in eval(conditional), do not remove this import
+
+
+# read the menu
+file = open(resolveFilename(SCOPE_SKINS, "menu.xml"))
+mdom = parse(file)
+file.close()
 
 
 def MenuEntryPixmap(key, png_cache):
@@ -38,14 +42,6 @@ def MenuEntryPixmap(key, png_cache):
 			png = LoadPixmap(resolveFilename(SCOPE_GUISKIN, pngPath), cached=True, width=w, height=0 if pngPath.endswith(".svg") else h)
 	return png
 
-# read the menu
-file = open(resolveFilename(SCOPE_SKINS, "menu.xml"), "r")
-mdom = parse(file)
-file.close()
-
-lastMenuID = None
-
-nomainmenupath = False if exists(resolveFilename(SCOPE_CURRENT_SKIN, "mainmenu")) else True
 
 def default_skin():
 	for line in open("/etc/enigma2/settings"):
@@ -128,13 +124,11 @@ class Menu(Screen, ProtectedScreen):
 	png_cache = {}
 
 	def okbuttonClick(self):
-		global lastMenuID
 		if self.number:
 			self["menu"].setIndex(self.number - 1)
 		self.resetNumberKey()
 		selection = self["menu"].getCurrent()
 		if selection and selection[1]:
-			lastMenuID = selection[2]
 			selection[1]()
 
 	def execText(self, text):
@@ -189,9 +183,7 @@ class Menu(Screen, ProtectedScreen):
 		self.menuClosed(*res)
 
 	def menuClosed(self, *res):
-		global lastMenuID
 		if res and res[0]:
-			lastMenuID = None
 			self.close(True)
 		elif len(self.list) == 1:
 			self.close()

--- a/lib/python/Screens/NetworkSetup.py
+++ b/lib/python/Screens/NetworkSetup.py
@@ -528,26 +528,8 @@ class AdapterSetup(ConfigListScreen, Screen):
 
 				self.createConfig()
 
-				self["OkCancelActions"] = HelpableActionMap(self, ["OkCancelActions"],
-						{
-						"cancel": (self.keyCancel, _("exit network adapter configuration")),
-						"ok": (self.keySave, _("activate network adapter configuration")),
-						})
-
-				self["ColorActions"] = HelpableActionMap(self, ["ColorActions"],
-						{
-						"red": (self.keyCancel, _("exit network adapter configuration")),
-						"green": (self.keySave, _("activate network adapter configuration")),
-						"blue": (self.KeyBlue, _("open nameserver configuration")),
-						})
-
-				self["actions"] = NumberActionMap(["SetupActions"],
-				{
-						"ok": self.keySave,
-				}, -2)
-
 				self.list = []
-				ConfigListScreen.__init__(self, self.list, session=self.session)
+				ConfigListScreen.__init__(self, self.list, session=self.session, fullUI=True)
 				self.createSetup()
 				self.onLayoutFinish.append(self.layoutFinished)
 				self.onClose.append(self.cleanup)

--- a/lib/python/Screens/ParentalControlSetup.py
+++ b/lib/python/Screens/ParentalControlSetup.py
@@ -4,7 +4,6 @@ from Components.ConfigList import ConfigListScreen
 from Components.ActionMap import NumberActionMap
 from Components.config import config, ConfigNothing, NoSave, configfile
 
-from Components.Sources.StaticText import StaticText
 from Screens.MessageBox import MessageBox
 from Screens.InputBox import PinInput
 from Tools.BoundFunction import boundFunction
@@ -35,21 +34,10 @@ class ParentalControlSetup(ConfigListScreen, ProtectedScreen, Screen):
 		# for the skin: first try ParentalControlSetup, then Setup, this allows individual skinning
 		self.skinName = ["ParentalControlSetup", "Setup"]
 		self.setTitle(_("Parental control setup"))
-		self.onChangedEntry = []
 
 		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.changedEntry)
+		ConfigListScreen.__init__(self, self.list, session=self.session, on_change=self.changedEntry, fullUI=True)
 		self.createSetup(initial=True)
-
-		self["actions"] = NumberActionMap(["SetupActions", "MenuActions"],
-		{
-			"cancel": self.keyCancel,
-			"save": self.keySave,
-			"menu": self.closeRecursive,
-		}, -2)
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self.recursive = False
 
 	def isProtected(self):
 		return (not config.ParentalControl.setuppinactive.value and config.ParentalControl.servicepinactive.value) or\
@@ -92,7 +80,7 @@ class ParentalControlSetup(ConfigListScreen, ProtectedScreen, Screen):
 			self.list.append(self.changePin)
 		self["config"].list = self.list
 
-	def keyOK(self):
+	def keySelect(self):
 		if self["config"].l.getCurrentSelection() == self.changePin:
 			if config.ParentalControl.servicepin[0].value:
 				self.session.openWithCallback(self.oldPinEntered, PinInput, pinList=[x.value for x in config.ParentalControl.servicepin], triesEntry=config.ParentalControl.retries.servicepin, title=_("Please enter the old PIN code"), windowTitle=_("Enter PIN code"))
@@ -114,21 +102,6 @@ class ParentalControlSetup(ConfigListScreen, ProtectedScreen, Screen):
 		ConfigListScreen.keyRight(self)
 		self.createSetup()
 
-	def cancelCB(self, value):
-		self.keySave()
-
-	def keyCancel(self):
-		if self["config"].isChanged():
-			self.session.openWithCallback(self.cancelConfirm, MessageBox, _("Really close without saving settings?"))
-		else:
-			self.close()
-
-	def cancelConfirm(self, answer):
-		if answer:
-			for x in self["config"].list:
-				x[1].cancel()
-			self.close()
-
 	def keySave(self):
 		if self["config"].isChanged():
 			for x in self["config"].list:
@@ -136,11 +109,7 @@ class ParentalControlSetup(ConfigListScreen, ProtectedScreen, Screen):
 			configfile.save()
 			from Components.ParentalControl import parentalControl
 			parentalControl.hideBlacklist()
-		self.close(self.recursive)
-
-	def closeRecursive(self):
-		self.recursive = True
-		self.keySave()
+		self.close()
 
 	def keyNumberGlobal(self, number):
 		pass

--- a/lib/python/Screens/Satconfig.py
+++ b/lib/python/Screens/Satconfig.py
@@ -535,7 +535,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			self.fillListWithAdvancedSatEntrys(Sat)
 		self["config"].list = self.list
 
-	def keyOk(self):
+	def keySelect(self):
 		if self.isChanged():
 			self.stopService()
 		if self["config"].getCurrent() == self.advancedSelectSatsEntry:
@@ -545,7 +545,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			conf = self.nimConfig.userSatellitesList
 			self.session.openWithCallback(boundFunction(self.updateConfUserSatellitesList, conf), SelectSatsEntryScreen, userSatlist=conf.value)
 		else:
-			self.keySave()
+			ConfigListScreen.keySelect(self)
 
 	def updateConfUserSatellitesList(self, conf, val=None):
 		if val is not None:
@@ -601,7 +601,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 		Screen.__init__(self, session)
 		self.list = []
 		ServiceStopScreen.__init__(self)
-		ConfigListScreen.__init__(self, self.list)
+		ConfigListScreen.__init__(self, self.list, on_change=self.changedEntry)
 
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("Save"))
@@ -610,7 +610,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 		self["description"] = Label("")
 		self["actions"] = ActionMap(["SetupActions", "SatlistShortcutAction"],
 		{
-			"ok": self.keyOk,
+			"ok": self.keySelect,
 			"save": self.keySave,
 			"cancel": self.keyCancel,
 			"changetype": self.changeConfigurationMode,
@@ -628,7 +628,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			return
 		ConfigListScreen.keyLeft(self)
 		if self["config"].getCurrent() in (self.advancedSelectSatsEntry, self.selectSatsEntry):
-			self.keyOk()
+			self.keySelect()
 		else:
 			self.newConfig()
 
@@ -643,7 +643,7 @@ class NimSetup(ConfigListScreen, ServiceStopScreen, Screen):
 			return
 		ConfigListScreen.keyRight(self)
 		if self["config"].getCurrent() in (self.advancedSelectSatsEntry, self.selectSatsEntry):
-			self.keyOk()
+			self.keySelect()
 		else:
 			self.newConfig()
 
@@ -961,12 +961,10 @@ class SelectSatsEntryScreen(Screen):
 		self["list"] = SelectionList(sat_list, enableWrapAround=True)
 		self["setupActions"] = ActionMap(["SetupActions", "ColorActions"],
 		{
-			"red": self.cancel,
-			"green": self.save,
 			"yellow": self.sortBy,
 			"blue": self["list"].toggleAllSelection,
 			"save": self.save,
-			"cancel": self.cancel,
+			"cancel": self.close,
 			"ok": self["list"].toggleSelection,
 		}, -2)
 		self.setTitle(_("Select satellites"))
@@ -974,9 +972,6 @@ class SelectSatsEntryScreen(Screen):
 	def save(self):
 		val = [x[0][1] for x in self["list"].list if x[0][3]]
 		self.close(str(val))
-
-	def cancel(self):
-		self.close(None)
 
 	def sortBy(self):
 		lst = self["list"].list

--- a/lib/python/Screens/ScanSetup.py
+++ b/lib/python/Screens/ScanSetup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from Screens.Screen import Screen
 from Screens.ServiceScan import ServiceScan
 from Components.config import config, ConfigSubsection, ConfigSelection, ConfigYesNo, ConfigInteger, ConfigSlider, ConfigEnableDisable, ConfigFloat
@@ -8,14 +7,12 @@ from Components.SystemInfo import BoxInfo
 from Components.ConfigList import ConfigListScreen
 from Components.NimManager import nimmanager, getConfigSatlist
 from Components.Label import Label
+from Tools.HardwareInfo import HardwareInfo
 from Tools.Transponder import getChannelNumber, supportedChannels, channel2frequency
 from Tools.Directories import fileExists
 from Screens.InfoBar import InfoBar
 from Screens.MessageBox import MessageBox
 from enigma import eTimer, eDVBFrontendParametersSatellite, eComponentScan, eDVBFrontendParametersTerrestrial, eDVBFrontendParametersCable, eConsoleAppContainer, eDVBResourceManager, eDVBFrontendParametersATSC
-
-
-MODEL = BoxInfo.getItem("model")
 
 
 def buildTerTransponder(frequency,
@@ -293,7 +290,7 @@ class CableTransponderSearchSupport:
 		except:
 			# older API
 			if nim_idx < 2:
-				if MODEL in ("dm500hd"):
+				if HardwareInfo().get_device_name() == "dm500hd":
 					bus = 2
 				else:
 					bus = nim_idx
@@ -608,7 +605,7 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		Screen.setTitle(self, _("Manual Scan"))
-
+		self.skinName = ["ScanSetup", "Setup"]
 		self.finished_cb = None
 		self.updateSatList()
 		self.service = session.nav.getCurrentService()
@@ -628,26 +625,19 @@ class ScanSetup(ConfigListScreen, Screen, CableTransponderSearchSupport, Terrest
 
 		self.session.postScanService = session.nav.getCurrentlyPlayingServiceOrGroup()
 
-		self["key_red"] = StaticText(_("Close"))
 		self["key_green"] = StaticText(_("Scan"))
 
-		self["actions"] = NumberActionMap(["SetupActions", "MenuActions", "ColorActions"],
+		self["actions"] = NumberActionMap(["SetupActions"],
 		{
-			"ok": self.keyGo,
 			"save": self.keyGo,
-			"cancel": self.keyCancel,
-			"red": self.keyCancel,
-			"green": self.keyGo,
-			"menu": self.doCloseRecursive,
 		}, -2)
 
 		self.statusTimer = eTimer()
 		self.statusTimer.callback.append(self.updateStatus)
 
 		self.list = []
-		ConfigListScreen.__init__(self, self.list)
+		ConfigListScreen.__init__(self, self.list, fullUI=True)
 		self["introduction"] = Label("")
-		self["description"] = Label("")
 		if self.scan_nims.value == "":
 			self["introduction"].text = _("Nothing to scan! Setup your tuner and try again.")
 			return
@@ -1713,18 +1703,12 @@ class ScanSimple(ConfigListScreen, Screen, CableTransponderSearchSupport, Terres
 	def __init__(self, session):
 		Screen.__init__(self, session)
 		Screen.setTitle(self, _("Automatic Scan"))
-
-		self["key_red"] = StaticText(_("Close"))
+		self.skinName = ["ScanSimple", "Setup"]
 		self["key_green"] = StaticText(_("Scan"))
 
 		self["actions"] = ActionMap(["SetupActions", "MenuActions", "ColorActions"],
 		{
-			"ok": self.keyGo,
 			"save": self.keyGo,
-			"cancel": self.keyCancel,
-			"menu": self.doCloseRecursive,
-			"red": self.keyCancel,
-			"green": self.keyGo,
 		}, -2)
 
 		self.session.postScanService = session.nav.getCurrentlyPlayingServiceOrGroup()
@@ -1782,7 +1766,7 @@ class ScanSimple(ConfigListScreen, Screen, CableTransponderSearchSupport, Terres
 			if self.t2_nim_found:
 				self.list.append((_("Blindscan terrestrial (if possible)"), self.scan_terrestrial_binary_scan))
 
-		ConfigListScreen.__init__(self, self.list)
+		ConfigListScreen.__init__(self, self.list, fullUI=True)
 		self["footer"] = Label(_("Press OK to scan"))
 
 	def getNetworksForNim(self, nim):

--- a/lib/python/Screens/Screen.py
+++ b/lib/python/Screens/Screen.py
@@ -338,5 +338,8 @@ class ScreenSummary(Screen):
 		if not isinstance(names, list):
 			names = [names]
 		self.skinName = ["%sSummary" % x for x in names]
+		className = self.__class__.__name__
+		if className != "ScreenSummary" and className not in self.skinName:  # e.g. if a module uses Screens.Setup.SetupSummary the skin needs to be available directly
+			self.skinName.append(className)
 		self.skinName.append("ScreenSummary")
 		self.skin = parent.__dict__.get("skinSummary", self.skin)  # If parent has a "skinSummary" defined, use that as default.

--- a/lib/python/Screens/Setup.py
+++ b/lib/python/Screens/Setup.py
@@ -1,192 +1,337 @@
 # -*- coding: utf-8 -*-
-from Screens.Screen import Screen
-from Components.ActionMap import NumberActionMap
-from Components.config import config, ConfigNothing, ConfigBoolean, ConfigSelection
-from Components.Label import Label
-from Components.SystemInfo import SystemInfo
+from xml.etree.ElementTree import fromstring
+
+from gettext import dgettext
+from os.path import getmtime, join as pathjoin
+from skin import setups, findSkinScreen, parameters  # noqa: F401  used in <item conditional="..."> to check if a screen name is available in the skin
+
+from Components.config import ConfigBoolean, ConfigNothing, ConfigSelection, config
 from Components.ConfigList import ConfigListScreen
+from Components.Label import Label
 from Components.Pixmap import Pixmap
+from Components.SystemInfo import BoxInfo
 from Components.Sources.StaticText import StaticText
-from Components.Sources.Boolean import Boolean
-from skin import parameters, findSkinScreen
-from enigma import eEnv
+from Screens.HelpMenu import HelpableScreen
+from Screens.Screen import Screen, ScreenSummary
+from Tools.Directories import SCOPE_CURRENT_SKIN, SCOPE_PLUGINS, SCOPE_SKIN, fileReadXML, resolveFilename
+from Tools.LoadPixmap import LoadPixmap
 
-import xml.etree.ElementTree
-
-# FIXME: use resolveFile!
-# read the setupmenu
-try:
-	# first we search in the current path
-	setupfile = open('data/setup.xml', 'r')
-except:
-	# if not found in the current path, we use the global datadir-path
-	setupfile = open(eEnv.resolve('${datadir}/enigma2/setup.xml'), 'r')
-setupdom = xml.etree.ElementTree.parse(setupfile)
-setupfile.close()
+domSetups = {}
+setupModTimes = {}
 
 
-def getConfigMenuItem(configElement):
-	for item in setupdom.getroot().findall('./setup/item/.'):
-		if item.text == configElement:
-			return _(item.attrib["text"]), eval(configElement)
-	return "", None
+class Setup(ConfigListScreen, Screen, HelpableScreen):
+	def __init__(self, session, setup, plugin=None, PluginLanguageDomain=None):
+		Screen.__init__(self, session)
+		HelpableScreen.__init__(self)
+		self.setup = setup
+		self.plugin = plugin
+		self.pluginLanguageDomain = PluginLanguageDomain
+		if not isinstance(self.skinName, list):
+			self.skinName = [self.skinName]
+		if setup:
+			self.skinName.append("Setup%s" % setup)  # DEBUG: Proposed for new setup screens.
+			self.skinName.append("setup_%s" % setup)
+		self.skinName.append("Setup")
+		self.list = []
+		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry, fullUI=True)
+		self["footnote"] = Label()
+		self["footnote"].hide()
+		self["description"] = Label()
+		self.createSetup()
+		self.loadSetupImage(setup)
+		if self.layoutFinished not in self.onLayoutFinish:
+			self.onLayoutFinish.append(self.layoutFinished)
+		if self.selectionChanged not in self["config"].onSelectionChanged:
+			self["config"].onSelectionChanged.append(self.selectionChanged)
 
+	def loadSetupImage(self, setup):
+		self.setupImage = None
+		if setups:
+			setupImage = setups.get(setup, setups.get("default", ""))
+			if setupImage:
+				self.setupImage = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, setupImage))
+				if self.setupImage:
+					self["setupimage"] = Pixmap()
 
-class SetupError(Exception):
-	def __init__(self, message):
-		self.msg = message
+	def changedEntry(self):
+		current = self["config"].getCurrent()
+		if current[1].isChanged():
+			self.manipulatedItems.append(current)  # keep track of all manipulated items including ones that have been removed from self["config"].list
+		elif current in self.manipulatedItems:
+			self.manipulatedItems.remove(current)
+		if isinstance(current[1], (ConfigBoolean, ConfigSelection)):
+			self.createSetup()
+		ConfigListScreen.changedEntry(self)  # force summary update immediately, not just on select/deselect
 
-	def __str__(self):
-		return self.msg
+	def createSetup(self, appendItems=None, prependItems=None):
+		oldList = self.list
+		self.showDefaultChanged = False
+		self.graphicSwitchChanged = False
+		self.list = prependItems or []
+		title = None
+		xmlData = setupDom(self.setup, self.plugin)
+		for setup in xmlData.findall("setup"):
+			if setup.get("key") == self.setup:
+				self.addItems(setup)
+				skin = setup.get("skin", None)
+				if skin and skin != "":
+					self.skinName.insert(0, skin)
+				title = setup.get("title", None)
+				# print("[Setup] [createSetup] %s" % title)
+				# If this break is executed then there can only be one setup tag with this key.
+				# This may not be appropriate if conditional setup blocks become available.
+				break
+		if appendItems:
+			self.list += appendItems
+		if title:
+			title = dgettext(self.pluginLanguageDomain, title) if self.pluginLanguageDomain else _(title)
+		self.setTitle(title if title else _("Setup"))
+		if not self.list:  # This forces the self["config"] list to be cleared if there are no eligible items available to be displayed.
+			self["config"].list = self.list
+		elif self.list != oldList or self.showDefaultChanged or self.graphicSwitchChanged:
+			currentItem = self["config"].getCurrent()
+			self["config"].list = self.list
+			if config.usage.sort_settings.value:
+				self["config"].list.sort(key=lambda x: x[0])
+			self.moveToItem(currentItem)
 
+	def addItems(self, parentNode, including=True):
+		for element in parentNode:
+			if not element.tag:
+				continue
+			if element.tag in ("elif", "else") and including:
+				break  # End of succesful if/elif branch - short-circuit rest of children.
+			include = self.includeElement(element)
+			if element.tag == "item":
+				if including and include:
+					self.addItem(element)
+			elif element.tag == "if":
+				if including:
+					self.addItems(element, including=include)
+			elif element.tag == "elif":
+				including = include
+			elif element.tag == "else":
+				including = True
 
-class SetupSummary(Screen):
+	def addItem(self, element):
+		if self.pluginLanguageDomain:
+			itemText = dgettext(self.pluginLanguageDomain, x) if (x := element.get("text")) else "* fix me *"
+			itemDescription = dgettext(self.pluginLanguageDomain, x) if (x := element.get("description")) else ""
+		else:
+			itemText = _(x) if (x := element.get("text")) else "* fix me *"
+			itemDescription = _(x) if (x := element.get("description")) else ""
+		item = eval(element.text or "")
+		if item == "":
+			self.list.append((self.formatItemText(itemText),))  # Add the comment line to the config list.
+		elif not isinstance(item, ConfigNothing):
+			self.list.append((self.formatItemText(itemText), item, self.formatItemDescription(item, itemDescription)))  # Add the item to the config list.
+		if item is config.usage.setupShowDefault:
+			self.showDefaultChanged = True
+		if item is config.usage.boolean_graphic:
+			self.graphicSwitchChanged = True
 
-	def __init__(self, session, parent):
-		Screen.__init__(self, session, parent=parent)
-		self["SetupTitle"] = StaticText(parent.title)
-		self["SetupEntry"] = StaticText("")
-		self["SetupValue"] = StaticText("")
-		self.onShow.append(self.addWatcher)
-		self.onHide.append(self.removeWatcher)
+	def formatItemText(self, itemText):
+		return itemText.replace("%s %s", "%s %s" % (BoxInfo.getItem("MachineBrand", ""), BoxInfo.getItem("MachineName", "")))
 
-	def addWatcher(self):
-		if hasattr(self.parent, "onChangedEntry"):
-			self.parent.onChangedEntry.append(self.selectionChanged)
-			self.parent["config"].onSelectionChanged.append(self.selectionChanged)
-			self.selectionChanged()
+	def formatItemDescription(self, item, itemDescription):
+		itemDescription = itemDescription.replace("%s %s", "%s %s" % (BoxInfo.getItem("MachineBrand", ""), BoxInfo.getItem("MachineName", "")))
+		if config.usage.setupShowDefault.value:
+			spacer = "\n" if config.usage.setupShowDefault.value == "newline" else "  "
+			itemDefault = item.toDisplayString(item.default)
+			itemDescription = _("%s%s(Default: %s)") % (itemDescription, spacer, itemDefault) if itemDescription and itemDescription != " " else _("Default: '%s'.") % itemDefault
+		return itemDescription
 
-	def removeWatcher(self):
-		if hasattr(self.parent, "onChangedEntry"):
-			self.parent.onChangedEntry.remove(self.selectionChanged)
-			self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
+	def includeElement(self, element):
+		itemLevel = int(element.get("level", 0))
+		if itemLevel > config.usage.setup_level.index:  # The item is higher than the current setup level.
+			return False
+		requires = element.get("requires")
+		if requires:
+			for require in [x.strip() for x in requires.split(";")]:
+				negate = require.startswith("!")
+				if negate:
+					require = require[1:]
+				if require.startswith("config."):
+					item = eval(require)
+					result = bool(item.value and item.value not in ("0", "Disable", "disable", "False", "false", "No", "no", "Off", "off"))
+				else:
+					result = bool(BoxInfo.getItem(require, False))
+				if require and negate == result:  # The item requirements are not met.
+					return False
+		conditional = element.get("conditional")
+		return not conditional or eval(conditional)
+
+	def layoutFinished(self):
+		if self.setupImage:
+			self["setupimage"].instance.setPixmap(self.setupImage)
+		if not self["config"]:
+			print("[Setup] No setup items available!")
 
 	def selectionChanged(self):
-		self["SetupEntry"].text = self.parent.getCurrentEntry()
-		self["SetupValue"].text = self.parent.getCurrentValue()
+		if self["config"]:
+			self.setFootnote(None)
 
+	def setFootnote(self, footnote):
+		if footnote is None:
+			if self.getCurrentEntry().endswith("*"):
+				self["footnote"].text = _("* = Restart Required")
+				self["footnote"].show()
+			else:
+				self["footnote"].text = ""
+				self["footnote"].hide()
+		else:
+			self["footnote"].text = footnote
+			self["footnote"].show()
 
-class Setup(ConfigListScreen, Screen):
-
-	ALLOW_SUSPEND = False  # Not allow users to shutdown from Setup based screens.
-
-	def __init__(self, session, setup):
-		Screen.__init__(self, session)
-		# for the skin: first try a setup_<setupID>, then Setup
-		self.skinName = ["setup_" + setup, "Setup"]
-		self.list = []
-		self.force_update_list = False
-
-		xmldata = setupdom.getroot()
-		for x in xmldata.findall("setup"):
-			if x.get("key") == setup:
-				self.setup = x
-				break
-
-		self.seperation = int(self.setup.get('separation', '0'))
-
-		#check for list.entries > 0 else self.close
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
-		self["description"] = Label("")
-		self["HelpWindow"] = Pixmap()
-		self["HelpWindow"].hide()
-		self["VKeyIcon"] = Boolean(False)
-
-		self["actions"] = NumberActionMap(["SetupActions", "MenuActions"],
-			{
-				"cancel": self.keyCancel,
-				"save": self.keySave,
-				"menu": self.closeRecursive,
-			}, -2)
-
-		ConfigListScreen.__init__(self, self.list, session=session, on_change=self.changedEntry)
-		self.createSetupList()
-		self.title = _(self.setup.get("title", ""))
-
-	def createSetupList(self):
-		currentItem = self["config"].getCurrent()
-		self.list = []
-		for x in self.setup:
-			if not x.tag:
-				continue
-			if x.tag == 'item':
-				item_level = int(x.get("level", 0))
-
-				if item_level > config.usage.setup_level.index:
-					continue
-
-				requires = x.get("requires")
-				if requires:
-					meets = True
-					for requires in requires.split(';'):
-						negate = requires.startswith('!')
-						if negate:
-							requires = requires[1:]
-						if requires.startswith('config.'):
-							try:
-								item = eval(requires)
-								SystemInfo[requires] = True if item.value and item.value not in ("0", "False", "false", "off") else False
-							except AttributeError:
-								print('[Setup] unknown "requires" config element:', requires)
-
-						if requires:
-							if not SystemInfo.get(requires, False):
-								if not negate:
-									meets = False
-									break
-							else:
-								if negate:
-									meets = False
-									break
-					if not meets:
-						continue
-				conditional = x.get("conditional")
-				if conditional and not eval(conditional):
-					continue
-
-				item_text = _(x.get("text", "??"))
-				item_description = _(x.get("description", " ")) # don't change
-				b = eval(x.text or "")
-				if b == "":
-					continue
-				#add to configlist
-				item = b
-				# the first b is the item itself, ignored by the configList.
-				# the second one is converted to string.
-				if not isinstance(item, ConfigNothing):
-					self.list.append((item_text, item, item_description))
-		self["config"].setList(self.list)
-		if config.usage.sort_settings.value:
-			self["config"].list.sort()
-		self.moveToItem(currentItem)
+	def getFootnote(self):
+		return self["footnote"].text
 
 	def moveToItem(self, item):
 		if item != self["config"].getCurrent():
 			self["config"].setCurrentIndex(self.getIndexFromItem(item))
 
 	def getIndexFromItem(self, item):
-		return self["config"].list.index(item) if item in self["config"].list else 0
+		if item is None:  # If there is no item position at the top of the config list.
+			return 0
+		if item in self["config"].list:  # If the item is in the config list position to that item.
+			return self["config"].list.index(item)
+		for pos, data in enumerate(self["config"].list):
+			if data[0] == item[0] and data[1] == item[1]:  # If the label and config class match then position to that item.
+				return pos
+		return 0  # We can't match the item to the config list then position to the top of the list.
 
-	def changedEntry(self):
-		if isinstance(self["config"].getCurrent()[1], ConfigBoolean) or isinstance(self["config"].getCurrent()[1], ConfigSelection):
-			self.saveAll()
-			self.createSetupList()
+	def createSummary(self):
+		return SetupSummary
+
+
+class SetupSummary(ScreenSummary):
+
+	def __init__(self, session, parent):
+		ScreenSummary.__init__(self, session, parent=parent)
+		self["entry"] = StaticText("")  # DEBUG: Proposed for new summary screens.
+		self["value"] = StaticText("")  # DEBUG: Proposed for new summary screens.
+		self["SetupTitle"] = StaticText(parent.getTitle())
+		self["SetupEntry"] = StaticText("")
+		self["SetupValue"] = StaticText("")
+		if self.addWatcher not in self.onShow:
+			self.onShow.append(self.addWatcher)
+		if self.removeWatcher not in self.onHide:
+			self.onHide.append(self.removeWatcher)
+
+	def addWatcher(self):
+		if self.selectionChanged not in self.parent.onChangedEntry:
+			self.parent.onChangedEntry.append(self.selectionChanged)
+		if self.selectionChanged not in self.parent["config"].onSelectionChanged:
+			self.parent["config"].onSelectionChanged.append(self.selectionChanged)
+		self.selectionChanged()
+
+	def removeWatcher(self):
+		if self.selectionChanged in self.parent.onChangedEntry:
+			self.parent.onChangedEntry.remove(self.selectionChanged)
+		if self.selectionChanged in self.parent["config"].onSelectionChanged:
+			self.parent["config"].onSelectionChanged.remove(self.selectionChanged)
 
 	def selectionChanged(self):
-		if self["config"]:
-			self["description"].text = self.getCurrentDescription()
-		else:
-			self["description"].text = _("There are no items currently available for this screen.")
-
-	def run(self):
-		self.keySave()
+		self["entry"].text = self.parent.getCurrentEntry()  # DEBUG: Proposed for new summary screens.
+		self["value"].text = self.parent.getCurrentValue()  # DEBUG: Proposed for new summary screens.
+		self["SetupEntry"].text = self.parent.getCurrentEntry()
+		self["SetupValue"].text = self.parent.getCurrentValue()
 
 
-def getSetupTitle(id):
-	xmldata = setupdom.getroot()
-	for x in xmldata.findall("setup"):
-		if x.get("key") == id:
-			return x.get("title", "")
-	print("[Setup] Error: Unknown setup id '%s'!" % repr(id))
-	raise SetupError("unknown setup id '%s'!" % repr(id))
+# Read the setup XML file.
+#
+def setupDom(setup=None, plugin=None):
+	# Constants for checkItems()
+	ROOT_ALLOWED = ("setup", )  # Tags allowed in top level of setupxml entry.
+	ELEMENT_ALLOWED = ("item", "if")  # noqa: F841 Tags allowed in top level of setup entry.
+	IF_ALLOWED = ("item", "if", "elif", "else")  # Tags allowed inside <if />.
+	AFTER_ELSE_ALLOWED = ("item", "if")  # Tags allowed after <elif /> or <else />.
+	CHILDREN_ALLOWED = ("setup", "if", )  # Tags that may have children.
+	TEXT_ALLOWED = ("item", )  # Tags that may have non-whitespace text (or tail).
+	KEY_ATTRIBUTES = {  # Tags that have a reference key mandatory attribute.
+		"setup": "key",
+		"item": "text"
+	}
+	MANDATORY_ATTRIBUTES = {  # Tags that have a list of mandatory attributes.
+		"setup": ("key", "title"),
+		"item": ("text", )
+	}
+
+	def checkItems(parentNode, key, allowed=ROOT_ALLOWED, mandatory=MANDATORY_ATTRIBUTES, reference=KEY_ATTRIBUTES):
+		keyText = " in '%s'" % key if key else ""
+		for element in parentNode:
+			if element.tag not in allowed:
+				print("[Setup] Error: Tag '%s' not permitted%s!  (Permitted: '%s')" % (element.tag, keyText, ", ".join(allowed)))
+				continue
+			if mandatory and element.tag in mandatory:
+				valid = True
+				for attrib in mandatory[element.tag]:
+					if element.get(attrib) is None:
+						print("[Setup] Error: Tag '%s'%s does not contain the mandatory '%s' attribute!" % (element.tag, keyText, attrib))
+						valid = False
+				if not valid:
+					continue
+			if element.tag not in TEXT_ALLOWED:
+				if element.text and not element.text.isspace():
+					print("[Setup] Tag '%s'%s contains text '%s'." % (element.tag, keyText, element.text.strip()))
+				if element.tail and not element.tail.isspace():
+					print("[Setup] Tag '%s'%s has trailing text '%s'." % (element.tag, keyText, element.text.strip()))
+			if element.tag not in CHILDREN_ALLOWED and len(element):
+				itemKey = ""
+				if element.tag in reference:
+					itemKey = " (%s)" % element.get(reference[element.tag])
+				print("[Setup] Tag '%s'%s%s contains children where none expected." % (element.tag, itemKey, keyText))
+			if element.tag in CHILDREN_ALLOWED:
+				if element.tag in reference:
+					key = element.get(reference[element.tag])
+				checkItems(element, key, allowed=IF_ALLOWED)
+			elif element.tag == "else":
+				allowed = AFTER_ELSE_ALLOWED  # else and elif not permitted after else
+			elif element.tag == "elif":
+				pass
+
+	setupFileDom = fromstring("<setupxml />")
+	setupFile = resolveFilename(SCOPE_PLUGINS, pathjoin(plugin, "setup.xml")) if plugin else resolveFilename(SCOPE_SKIN, "setup.xml")
+	global domSetups, setupModTimes
+	try:
+		modTime = getmtime(setupFile)
+	except (IOError, OSError) as err:
+		print("[Setup] Error: Unable to get '%s' modified time - Error (%d): %s!" % (setupFile, err.errno, err.strerror))
+		if setupFile in domSetups:
+			del domSetups[setupFile]
+		if setupFile in setupModTimes:
+			del setupModTimes[setupFile]
+		return setupFileDom  # we can't access setup.xml so return an empty dom
+	cached = setupFile in domSetups and setupFile in setupModTimes and setupModTimes[setupFile] == modTime
+	print("[Setup] XML%s setup file '%s', using element '%s'%s." % (" cached" if cached else "", setupFile, setup, " from plugin '%s'" % plugin if plugin else ""))
+	if cached:
+		return domSetups[setupFile]
+	if setupFile in domSetups:
+		del domSetups[setupFile]
+	if setupFile in setupModTimes:
+		del setupModTimes[setupFile]
+	fileDom = fileReadXML(setupFile)
+	if fileDom:
+		checkItems(fileDom, None)
+		setupFileDom = fileDom
+		domSetups[setupFile] = setupFileDom
+		setupModTimes[setupFile] = modTime
+	return setupFileDom
+
+# Temporary legacy interface.
+# Not used any enigma2 module. Known to be used by the Heinz plugin.
+#
+
+
+def setupdom(setup=None, plugin=None):
+	return setupDom(setup, plugin)
+
+# Only used in AudioSelection screen...
+#
+
+def getConfigMenuItem(configElement):
+	for item in setupDom().findall("./setup/item/."):
+		if item.text == configElement:
+			return _(item.attrib["text"]), eval(configElement)
+	return "", None

--- a/lib/python/Screens/SetupFallbacktuner.py
+++ b/lib/python/Screens/SetupFallbacktuner.py
@@ -1,47 +1,16 @@
-# -*- coding: utf-8 -*-
-from Screens.Screen import Screen
-from Components.Label import Label
-from Components.ActionMap import ActionMap
-from Components.Pixmap import Pixmap
-from Components.Sources.Boolean import Boolean
-from Components.Sources.StaticText import StaticText
+from Screens.Setup import Setup
 from Components.config import config, configfile, ConfigSelection, ConfigIP, ConfigInteger, ConfigBoolean
-from Components.ConfigList import ConfigListScreen
 from Components.ImportChannels import ImportChannels
 
 from enigma import getPeerStreamingBoxes
 
 
-class SetupFallbacktuner(ConfigListScreen, Screen):
+class SetupFallbacktuner(Setup):
 	def __init__(self, session):
-		Screen.__init__(self, session)
-		Screen.setTitle(self, _("Fallback tuner setup"))
-		self.skinName = ["FallbackTunerSetup", "Setup"]
-		self.onChangedEntry = []
-		ConfigListScreen.__init__(self, [], session=session, on_change=self.changedEntry)
-
-		self["actions2"] = ActionMap(["SetupActions"],
-		{
-			"ok": self.run,
-			"menu": self.keyCancel,
-			"cancel": self.keyCancel,
-			"save": self.run,
-		}, -2)
-
-		self["key_red"] = StaticText(_("Exit"))
-		self["key_green"] = StaticText(_("Save"))
-
-		self["description"] = Label("")
-		self["VKeyIcon"] = Boolean(False)
-		self["HelpWindow"] = Pixmap()
-		self["HelpWindow"].hide()
-
-		self.force_update_list = False
 		self.createConfig()
-		self.createSetup()
+		Setup.__init__(self, session, None)
+		self.title = _("Fallback tuner setup")
 		self.remote_fallback_prev = config.usage.remote_fallback_import.value
-		self["config"].onSelectionChanged.append(self.selectionChanged)
-		self.selectionChanged()
 
 	def createConfig(self):
 
@@ -214,20 +183,7 @@ class SetupFallbacktuner(ConfigListScreen, Screen):
 						_("URL of fallback remote receiver")))
 		self["config"].list = self.list
 
-	def selectionChanged(self):
-		if self.force_update_list:
-			self["config"].onSelectionChanged.remove(self.selectionChanged)
-			self.createSetup()
-			self["config"].onSelectionChanged.append(self.selectionChanged)
-			self.force_update_list = False
-		if not (isinstance(self["config"].getCurrent()[1], ConfigBoolean) or isinstance(self["config"].getCurrent()[1], ConfigSelection)):
-			self.force_update_list = True
-
-	def changedEntry(self):
-		if isinstance(self["config"].getCurrent()[1], ConfigBoolean) or isinstance(self["config"].getCurrent()[1], ConfigSelection):
-			self.createSetup()
-
-	def run(self):
+	def keySave(self):
 		if self.avahiselect.value == "ip":
 			config.usage.remote_fallback.value = "http://%d.%d.%d.%d:%d" % (tuple(self.ip.value) + (self.port.value,))
 		elif self.avahiselect.value != "url":

--- a/lib/python/Screens/SleepTimerEdit.py
+++ b/lib/python/Screens/SleepTimerEdit.py
@@ -1,138 +1,117 @@
-# -*- coding: utf-8 -*-
 from Screens.InfoBar import InfoBar
-from Screens.Screen import Screen
-from Screens.MessageBox import MessageBox
-from Components.ActionMap import ActionMap
-from Components.ConfigList import ConfigListScreen
-from Components.Label import Label
-from Components.Sources.StaticText import StaticText
+from Screens.Setup import Setup
 from Components.config import config
 from enigma import eEPGCache
 from time import time, localtime, mktime
 
 
-class SleepTimerEdit(ConfigListScreen, Screen):
+class SleepTimerEdit(Setup):
 	def __init__(self, session):
-		Screen.__init__(self, session)
+		Setup.__init__(self, session, None)
 		self.skinName = ["SleepTimerSetup", "Setup"]
 		self.setTitle(_("SleepTimer Configuration"))
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("Save"))
-		self["description"] = Label("")
-
-		self.list = []
-		ConfigListScreen.__init__(self, self.list, session=session)
-		self.createSetup()
-
-		self["setupActions"] = ActionMap(["SetupActions", "ColorActions"],
-		{
-			"green": self.ok,
-			"red": self.cancel,
-			"cancel": self.cancel,
-			"ok": self.ok,
-		}, -2)
 
 	def createSetup(self):
-		self.list = []
+		conflist = []
 		if InfoBar.instance and InfoBar.instance.sleepTimer.isActive():
 			statusSleeptimerText = _("(activated +%d min)") % InfoBar.instance.sleepTimerState()
 		else:
 			statusSleeptimerText = _("(not activated)")
-		self.list.append((_("Sleeptimer") + " " + statusSleeptimerText,
+		conflist.append((_("Sleeptimer") + " " + statusSleeptimerText,
 			config.usage.sleep_timer,
 			_("Configure the duration in minutes for the sleeptimer. Select this entry and click OK or green to start/stop the sleeptimer")))
-		self.list.append((_("Inactivity Sleeptimer"),
+		conflist.append((_("Inactivity Sleeptimer"),
 			config.usage.inactivity_timer,
 			_("Configure the duration in hours the receiver should go to standby when the receiver is not controlled.")))
 		if int(config.usage.inactivity_timer.value):
-			self.list.append((_("Specify timeframe to ignore inactivity sleeptimer"),
+			conflist.append((_("Specify timeframe to ignore inactivity sleeptimer"),
 				config.usage.inactivity_timer_blocktime,
 				_("When enabled you can specify a timeframe when the inactivity sleeptimer is ignored. Not the detection is disabled during this timeframe but the inactivity timeout is disabled")))
 			if config.usage.inactivity_timer_blocktime.value:
-				self.list.append((_("Set blocktimes by weekday"),
+				conflist.append((_("Set blocktimes by weekday"),
 					config.usage.inactivity_timer_blocktime_by_weekdays,
 					_("Specify if you want to set the blocktimes separately by weekday")))
 				if config.usage.inactivity_timer_blocktime_by_weekdays.value:
 					for i in range(7):
-						self.list.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
+						conflist.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
 							config.usage.inactivity_timer_blocktime_day[i]))
 						if config.usage.inactivity_timer_blocktime_day[i].value:
-							self.list.append((_("Start time to ignore inactivity sleeptimer"),
+							conflist.append((_("Start time to ignore inactivity sleeptimer"),
 								config.usage.inactivity_timer_blocktime_begin_day[i],
 								_("Specify the start time when the inactivity sleeptimer should be ignored")))
-							self.list.append((_("End time to ignore inactivity sleeptimer"),
+							conflist.append((_("End time to ignore inactivity sleeptimer"),
 								config.usage.inactivity_timer_blocktime_end_day[i],
 								_("Specify the end time until the inactivity sleeptimer should be ignored")))
-							self.list.append((_("Specify extra timeframe to ignore inactivity sleeptimer"),
+							conflist.append((_("Specify extra timeframe to ignore inactivity sleeptimer"),
 								config.usage.inactivity_timer_blocktime_extra_day[i],
 								_("When enabled you can specify an extra timeframe when the inactivity sleeptimer is ignored. Not the detection is disabled during this timeframe but the inactivity timeout is disabled")))
 							if config.usage.inactivity_timer_blocktime_extra_day[i].value:
-								self.list.append((_("Extra start time to ignore inactivity sleeptimer"),
+								conflist.append((_("Extra start time to ignore inactivity sleeptimer"),
 									config.usage.inactivity_timer_blocktime_extra_begin_day[i],
 									_("Specify the extra start time when the inactivity sleeptimer should be ignored")))
-								self.list.append((_("Extra end time to ignore inactivity sleeptimer"),
+								conflist.append((_("Extra end time to ignore inactivity sleeptimer"),
 									config.usage.inactivity_timer_blocktime_extra_end_day[i],
 									_("Specify the extra end time until the inactivity sleeptimer should be ignored")))
 				else:
-					self.list.append((_("Start time to ignore inactivity sleeptimer"),
+					conflist.append((_("Start time to ignore inactivity sleeptimer"),
 						config.usage.inactivity_timer_blocktime_begin,
 						_("Specify the start time when the inactivity sleeptimer should be ignored")))
-					self.list.append((_("End time to ignore inactivity sleeptimer"),
+					conflist.append((_("End time to ignore inactivity sleeptimer"),
 						config.usage.inactivity_timer_blocktime_end,
 						_("Specify the end time until the inactivity sleeptimer should be ignored")))
-					self.list.append((_("Specify extra timeframe to ignore inactivity sleeptimer"),
+					conflist.append((_("Specify extra timeframe to ignore inactivity sleeptimer"),
 						config.usage.inactivity_timer_blocktime_extra,
 						_("When enabled you can specify an extra timeframe when the inactivity sleeptimer is ignored. Not the detection is disabled during this timeframe but the inactivity timeout is disabled")))
 					if config.usage.inactivity_timer_blocktime_extra.value:
-						self.list.append((_("Extra start time to ignore inactivity sleeptimer"),
+						conflist.append((_("Extra start time to ignore inactivity sleeptimer"),
 							config.usage.inactivity_timer_blocktime_extra_begin,
 							_("Specify the extra start time when the inactivity sleeptimer should be ignored")))
-						self.list.append((_("Extra end time to ignore inactivity sleeptimer"),
+						conflist.append((_("Extra end time to ignore inactivity sleeptimer"),
 							config.usage.inactivity_timer_blocktime_extra_end,
 							_("Specify the extra end time until the inactivity sleeptimer should be ignored")))
-		self.list.append((_("Shutdown when in Standby"),
+		conflist.append((_("Shutdown when in Standby"),
 			config.usage.standby_to_shutdown_timer,
 			_("Configure the duration when the receiver should go to shut down in case the receiver is in standby mode.")))
 		if int(config.usage.standby_to_shutdown_timer.value):
-			self.list.append((_("Specify timeframe to ignore the shutdown in standby"),
+			conflist.append((_("Specify timeframe to ignore the shutdown in standby"),
 				config.usage.standby_to_shutdown_timer_blocktime,
 				_("When enabled you can specify a timeframe to ignore the shutdown timer when the receiver is in standby mode")))
 			if config.usage.standby_to_shutdown_timer_blocktime.value:
-				self.list.append((_("Start time to ignore shutdown in standby"),
+				conflist.append((_("Start time to ignore shutdown in standby"),
 					config.usage.standby_to_shutdown_timer_blocktime_begin,
 					_("Specify the start time to ignore the shutdown timer when the receiver is in standby mode")))
-				self.list.append((_("End time to ignore shutdown in standby"),
+				conflist.append((_("End time to ignore shutdown in standby"),
 					config.usage.standby_to_shutdown_timer_blocktime_end,
 					_("Specify the end time to ignore the shutdown timer when the receiver is in standby mode")))
-		self.list.append((_("Enable wakeup timer"),
+		conflist.append((_("Enable wakeup timer"),
 			config.usage.wakeup_enabled,
 			_("Note: when enabled, and you do want standby mode after wake up, set option 'Startup to Standby' as 'No, except Wakeup timer'.")))
 		if config.usage.wakeup_enabled.value != "no":
 			for i in range(7):
-				self.list.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
+				conflist.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
 					config.usage.wakeup_day[i]))
 				if config.usage.wakeup_day[i].value:
-					self.list.append((_("Wakeup time"),
+					conflist.append((_("Wakeup time"),
 						config.usage.wakeup_time[i]))
-		self.list.append((_("Enable power off timer"),
+		conflist.append((_("Enable power off timer"),
 			config.usage.poweroff_enabled,
 			_("Automatically power off box to deep standby mode.")))
 		if config.usage.poweroff_enabled.value:
 			for i in range(7):
-				self.list.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
+				conflist.append(([_("Monday"), _("Tuesday"), _("Wednesday"), _("Thursday"), _("Friday"), _("Saturday"), _("Sunday")][i],
 					config.usage.poweroff_day[i]))
 				if config.usage.poweroff_day[i].value:
-					self.list.append((_("Power off time"),
+					conflist.append((_("Power off time"),
 						config.usage.poweroff_time[i]))
-			self.list.append((_("Next day starts at"),
+			conflist.append((_("Next day starts at"),
 				config.usage.poweroff_nextday,
 				_("If the box is supposed to enter deep standby e.g. monday night at 1 AM, it actually is already tuesday. To enable this anyway, differing next day start time can be specified here.")))
-			self.list.append((_("Force power off (even when not in standby)"),
+			conflist.append((_("Force power off (even when not in standby)"),
 				config.usage.poweroff_force,
 				_("Forces deep standby, even when not in standby mode. Scheduled recordings remain unaffected.")))
-		self["config"].list = self.list
+		self["config"].list = conflist
 
-	def ok(self):
+	def keySave(self):
 		if self["config"].isChanged():
 			from Components.PowerOffTimer import powerOffTimer
 			powerOffTimer.powerStateTimerChanged(dont_currentday=powerOffTimer.getDontCurrentday())
@@ -159,24 +138,10 @@ class SleepTimerEdit(ConfigListScreen, Screen):
 			self.close(True)
 		self.close()
 
-	def cancel(self, answer=None):
-		if answer is None:
-			if self["config"].isChanged():
-				self.session.openWithCallback(self.cancel, MessageBox, _("Really close without saving settings?"))
-			else:
-				self.close()
-		elif answer:
-			for x in self["config"].list:
-				x[1].cancel()
-			self.close()
-
-	def keyLeft(self):
-		ConfigListScreen.keyLeft(self)
-		self.createSetup()
-
-	def keyRight(self):
-		ConfigListScreen.keyRight(self)
-		self.createSetup()
+	def keyMenuCallback(self, answer):
+		Setup.keyMenuCallback(self, answer)
+		if answer and self.getCurrentEntry().startswith(_("Sleeptimer")):
+			self.keySave()
 
 	def currentEventTime(self):
 		remaining = 0

--- a/lib/python/Screens/TimeDateInput.py
+++ b/lib/python/Screens/TimeDateInput.py
@@ -1,34 +1,14 @@
-# -*- coding: utf-8 -*-
-from Screens.Screen import Screen
-from Components.config import config, ConfigClock, ConfigDateTime
-from Components.ActionMap import NumberActionMap
-from Components.ConfigList import ConfigListScreen
-from Components.Sources.StaticText import StaticText
+from Screens.Setup import Setup
+from Components.config import ConfigClock, ConfigDateTime
 import time
 import datetime
 
 
-class TimeDateInput(ConfigListScreen, Screen):
+class TimeDateInput(Setup):
 	def __init__(self, session, config_time=None, config_date=None):
-		Screen.__init__(self, session)
-		self.setTitle(_("Date/time input"))
-		self["key_red"] = StaticText(_("Cancel"))
-		self["key_green"] = StaticText(_("OK"))
-
 		self.createConfig(config_date, config_time)
-
-		self["actions"] = NumberActionMap(["SetupActions", "OkCancelActions", "ColorActions"],
-		{
-			"ok": self.keyGo,
-			"green": self.keyGo,
-			"save": self.keyGo,
-			"red": self.keyCancel,
-			"cancel": self.keyCancel,
-		}, -2)
-
-		self.list = []
-		ConfigListScreen.__init__(self, self.list)
-		self.createSetup(self["config"])
+		Setup.__init__(self, session, None)
+		self.setTitle(_("Date/time input"))
 
 	def createConfig(self, conf_date, conf_time):
 		self.save_mask = 0
@@ -39,17 +19,16 @@ class TimeDateInput(ConfigListScreen, Screen):
 		if conf_date:
 			self.save_mask |= 2
 		else:
-			conf_date = ConfigDateTime(default=time.time(), formatstring=config.usage.date.dayfull.value, increment=86400)
+			conf_date = ConfigDateTime(default=time.time(), formatstring=_("%d.%B %Y"), increment=86400)
 		self.timeinput_date = conf_date
 		self.timeinput_time = conf_time
 
-	def createSetup(self, configlist):
+	def createSetup(self):
 		self.list = [
 			(_("Date"), self.timeinput_date),
 			(_("Time"), self.timeinput_time)
 		]
-		configlist.list = self.list
-		configlist.l.setList(self.list)
+		self["config"].list = self.list
 
 	def keyPageDown(self):
 		sel = self["config"].getCurrent()
@@ -68,7 +47,7 @@ class TimeDateInput(ConfigListScreen, Screen):
 		dt = datetime.datetime(d.tm_year, d.tm_mon, d.tm_mday, mytime[0], mytime[1])
 		return int(time.mktime(dt.timetuple()))
 
-	def keyGo(self):
+	def keySave(self):
 		time = self.getTimestamp(self.timeinput_date.value, self.timeinput_time.value)
 		if self.save_mask & 1:
 			self.timeinput_time.save()

--- a/lib/python/StartEnigma.py
+++ b/lib/python/StartEnigma.py
@@ -437,11 +437,11 @@ class PowerKey:
 				from Screens.Menu import MainMenu, mdom
 				root = mdom.getroot()
 				for x in root.findall("menu"):
-					y = x.find("id")
-					if y is not None:
-						id = y.get("val")
-						if id and id == selected[1]:
-							self.session.open(MainMenu, x)
+					if x.get("key") == "shutdown":
+						self.session.infobar = self
+						menu_screen = self.session.openWithCallback(self.MenuClosed, MainMenu, x)
+						menu_screen.setTitle(_("Standby / restart"))
+						break
 
 	def standby(self):
 		if not Screens.Standby.inStandby and self.session.current_dialog and self.session.current_dialog.ALLOW_SUSPEND and self.session.in_exec:


### PR DESCRIPTION
* First try to sync the config and ConfigList with OpenVix
* Add missing ConfigAction
* Fix graphical boolean switch.
This is stored as true/false and not as yes/no
* Revert 'Fix graphical boolean switch.'
This reverts commit 4c25b8c.
* Revert 'Add missing ConfigAction'
This reverts commit dbd2a0b.
* Revert 'First try to sync the config and ConfigList with OpenVix'
This reverts commit f76c1e1.
* Revert 'Ensure that changed values are saved before they disappear'
This reverts commit d8583db.
* [Menu] read menu texts from menu.xml, not setup.xml
Previous code is inefficient.

* Add warning when menu text is missing
* [Menu] Allow the conditional attribute to work in <menu> elements
* [Menu] description should be str, not bytes
* [Menu] remove unused 'parent' arg
* [Menu] simplify xml format
* [StartEnigma/Hotkey] add compatibility with new menu.xml format
* [Menu] add x.tag == 'plugin'
* [ScreenSummary] add summary module name to skin list

e.g. if a module other than Screens.Setup.Setup uses Screens.Setup.SetupSummary, screen name 'SetupSummary' will be missing from the skin list so it will get diverted to the wrong skin, most likely 'ScreenSummary'. This commit corrects that behaviour.

* [keymap] NavigationActions, activate KEY_REWIND and KEY_FASTFORWARD
* [Setup/ConfigList/config] update, among other things, allows reading setup.xml files in plugins, and removal of 100s of lines of code throughout enigma
* [CI] Remove unneeded code
* [InputDeviceSetup] Remove pointless code
* [NetworkSetup] remove redundant code
* [ParentalControlSetup] Make UI consistent with 'Setup' screens
* Fix graphical boolean switch.

This is stored as true/false and not as yes/no

* ﻿First try to sync the config and ConfigList with OpenVix
* Add missing ConfigAction
* Resolve issues around extra_args

Missing parameter and missing function

* Add missing setupShowDefault config
* ﻿Resolve merge issue
* Ensure that changed values are saved before they disappear

E.G. for languages when you disable more than one auto selected
language one of the languages was not anymore visible in the list and
therefore the value was stored, but not saved into the
/etc/enigma2/settings file. This change does ensure the value is saved.

* ExtraArgs was not implemented (yet) so no need to remove them
* Resolve GSOD with ConfigClock

We do not currently have the formats like OpenVix has with the different
clock formats (24 hours/12 hours style) where translators etc can also
configure it. I still think also the implementation of it may need some
discussion.

* Remove code in various modules that is already inherited from ConfigListScreen
* [config.py] fix BSoD
* [doc] add SETUP
* Add new option show setup default values in setup.xml
* Sleeptimer: OK Button now has a differnet function.
* MovieSelectionConfig: OK Button now has a differnet function.
* [SleepTimerEdit.py] use inherited code
* A config conditionally hidden but changed should be saved

In the previous work-a-round I did save all when the config was rebuild
but of course we only need to save configs that are conditionally not
shown only when they are changed.

I get to the config to an eval at this moment as I could not (quickly)
find a better way to get to the specific config

This avoids e.g. in the auto language setup when we put languages on
'None' while they disappear from the config list that the value is
actually not saved
See:
https://forums.openpli.org/topic/98887-auto-language-selection-options-not-saved-corectly/
* For a sleeptimer directly execute it when select in choicebox
* Correctly cover config items that are conditionaly hidden
See:
https://forums.openpli.org/topic/98887-auto-language-selection-options-not-saved-corectly/

In ec7ff0c for example when the setup was canceled the 'old' values
did not return at all and now with keeping a hiddenItems list we can
save them when required and also cancel them when required.
I also needed to add hasattr around it as te code is used on mulitple
locations where this list does not exist while also __init__ functions
of the ConfigList or so are not used

* Adjust Fastscan to new ConfigList functionality
* [Fastscan] inherit
* Resolve typo made in previous commit
* Resolve new config structure for InputDeviceSetup
* Remove some hasattr on the hiddenItems by ensure it is declared
* [Setup/ConfigList] self.hiddenItems, try a different approach
* [Satconfig.py] remove redundant code
* [Satconfig.py] use the UI actions provided in ConfigListScreen
* [ChannelSelection] InsertService, inherit UI from Setup
* [MovieSelection] MovieBrowserConfiguration, inherit UI from Setup
* [RecordPaths] inherit UI from Setup
* [SetupFallbackTuner] inherit UI from Setup
* [TimeDateInput] inherit UI from Setup
* [config.py] remove six and some cleanup
* [GraphMultiEPG] inherit UI from Setup (#3996)
* [HdmiCEC] inherit UI from ConfigListScreen (#3997)

---------

Co-authored-by: Littlesat <littlesat@openpli.org>
Co-authored-by: TwolDE2 <tonywhalley@web.de>

Follow: https://github.com/OpenPLi/enigma2/commit/49df463b5a9f088b32211117d0c852541c200dbe