### PR TITLE
Incorrect video mode info shown when viewing HDMI IN  live

### DIFF
--- a/data/setup.xml
+++ b/data/setup.xml
@@ -157,6 +157,7 @@
 		<item level="0" text="Show time remaining/elapsed" description="This option allows you choose how to display remaining time, or elapsed time, or both.">config.usage.swap_time_remaining_on_osd</item>
 		<item level="0" text="Show time elapsed as positive" description="This option allows you choose how to display elapsed time as + or -">config.usage.elapsed_time_positive_osd</item>
 		<item level="0" text="Show transponder remaining/elapsed as" description="This option allows you to choose how to display the remaining/elapsed time for live TV.">config.usage.swap_time_display_on_osd</item>
+		<item level="0" text="Show subservices *" description="This option allows you choose the option for Subservice indicator or selection.">config.usage.showInfoBarSubservices</item>
 		<item level="0" text="Media playback Remaining/Elapsed as" description="This option allows you to choose how to display the remaining/elapsed time for media playback.">config.usage.swap_media_time_display_on_osd</item>
 		<item level="2" text="Hide zap errors" description="When enabled, error messages related to zapping will not be shown.">config.usage.hide_zap_errors</item>
 		<item level="0" text="Show picon background color" description="This option allows you choose the background color of transparent picons.">config.usage.show_picon_bkgrn</item>

--- a/lib/dvb/db.cpp
+++ b/lib/dvb/db.cpp
@@ -181,6 +181,15 @@ RESULT eBouquet::setListName(const std::string &name)
 	return 0;
 }
 
+const eDVBService::cacheID eDVBService::audioCacheTags[] = {
+	eDVBService::cMPEGAPID, eDVBService::cAC3PID,
+	eDVBService::cAACHEAPID, eDVBService::cDDPPID,
+	eDVBService::cDTSPID, eDVBService::cAACAPID,
+	eDVBService::cLPCMPID, eDVBService::cDTSHDPID,
+};
+
+const int eDVBService::nAudioCacheTags = sizeof(eDVBService::audioCacheTags) / sizeof(eDVBService::audioCacheTags[0]);
+
 eDVBService::eDVBService()
 	:m_cache(0), m_flags(0), m_lcn(0)
 {
@@ -393,6 +402,15 @@ bool eDVBService::cacheEmpty()
 	if (m_cache)
 		for (int i=0; i < cacheMax; ++i)
 			if (m_cache[i] != -1)
+				return false;
+	return true;
+}
+
+bool eDVBService::cacheAudioEmpty()
+{
+	if (m_cache)
+		for (int i=0; i < nAudioCacheTags; ++i)
+			if (m_cache[audioCacheTags[i]] != -1)
 				return false;
 	return true;
 }

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -683,6 +683,7 @@ int eDVBFrontend::openFrontend()
 				ioctlMeasureEval("DTV_ENUM_DELSYS");
 			}
 			else
+			{
 				eWarning("[eDVBFrontend] ioctl FE_GET_PROPERTY/DTV_ENUM_DELSYS failed: %m");
 #else
 			/* no DTV_ENUM_DELSYS support */

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -656,7 +656,7 @@ int eDVBFrontend::openFrontend()
 		{
 			if (::ioctl(m_fd, FE_GET_INFO, &fe_info) < 0)
 			{
-				eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed");
+				eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 				::close(m_fd);
 				m_fd = -1;
 				return -1;
@@ -677,36 +677,43 @@ int eDVBFrontend::openFrontend()
 				{
 					fe_delivery_system_t delsys = (fe_delivery_system_t)p[0].u.buffer.data[p[0].u.buffer.len - 1];
 					m_delsys[delsys] = true;
-					setDeliverySystem(delsys);
 					if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[delsys]) < 0)
 						eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 				}
 				ioctlMeasureEval("DTV_ENUM_DELSYS");
 			}
 			else
-			{
 				eWarning("[eDVBFrontend] ioctl FE_GET_PROPERTY/DTV_ENUM_DELSYS failed: %m");
 #else
 			/* no DTV_ENUM_DELSYS support */
 			if (1)
-#endif
 			{
+#endif
 				/* old DVB API, fill delsys map with some defaults */
 				switch (fe_info.type)
 				{
 					case FE_QPSK:
 					{
 						m_delsys[SYS_DVBS] = true;
+						if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBS]) < 0)
+							eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 #if DVB_API_VERSION >= 5
 						if (m_dvbversion >= DVB_VERSION(5, 0))
 						{
-							if (fe_info.caps & FE_CAN_2G_MODULATION) m_delsys[SYS_DVBS2] = true;
+							if (fe_info.caps & FE_CAN_2G_MODULATION)
+							{
+								m_delsys[SYS_DVBS2] = true;
+								if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBS2]) < 0)
+									eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
+							}
 						}
 #endif
 						break;
 					}
 					case FE_QAM:
 					{
+						if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBC_ANNEX_B]) < 0)
+							eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 #ifdef HAVE_OLDE2_API
 						/* no need for a m_dvbversion check, SYS_DVBC_ANNEX_A replaced SYS_DVBC_ANNEX_AC (same value) */
 						m_delsys[SYS_DVBC_ANNEX_A] = true;
@@ -714,8 +721,14 @@ int eDVBFrontend::openFrontend()
 #if DVB_API_VERSION > 5 || DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 6
 						/* no need for a m_dvbversion check, SYS_DVBC_ANNEX_A replaced SYS_DVBC_ANNEX_AC (same value) */
 						m_delsys[SYS_DVBC_ANNEX_A] = true;
+						if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBC_ANNEX_A]) < 0)
+							eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
+						if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBC_ANNEX_C]) < 0)
+							eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 #else
 						m_delsys[SYS_DVBC_ANNEX_AC] = true;
+						if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBC_ANNEX_AC]) < 0)
+							eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 #endif
 #endif
 						break;
@@ -723,10 +736,17 @@ int eDVBFrontend::openFrontend()
 					case FE_OFDM:
 					{
 						m_delsys[SYS_DVBT] = true;
+						if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBT]) < 0)
+							eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 #if DVB_API_VERSION > 5 || DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 3
 						if (m_dvbversion >= DVB_VERSION(5, 3))
 						{
-							if (fe_info.caps & FE_CAN_2G_MODULATION) m_delsys[SYS_DVBT2] = true;
+							if (fe_info.caps & FE_CAN_2G_MODULATION)
+							{
+								m_delsys[SYS_DVBT2] = true;
+								if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[SYS_DVBT2]) < 0)
+									eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
+							}
 						}
 #endif
 						break;
@@ -749,10 +769,10 @@ int eDVBFrontend::openFrontend()
 	}
 	else
 	{
-		fe_info.frequency_min = 900000;
-		fe_info.frequency_max = 2200000;
+		m_fe_info[SYS_DVBS].frequency_min = m_fe_info[SYS_DVBS2].frequency_min = 900000;
+		m_fe_info[SYS_DVBS].frequency_max = m_fe_info[SYS_DVBS2].frequency_max = 2200000;
 
-		eDebug("[eDVBFrontend%d] opening frontend", m_dvbid);
+		eDebug("[eDVBFrontend] opening frontend %d", m_dvbid);
 		int tmp_fd = ::open(m_filename.c_str(), O_RDONLY | O_NONBLOCK | O_CLOEXEC);
 		if (tmp_fd < 0)
 		{
@@ -767,15 +787,33 @@ int eDVBFrontend::openFrontend()
 			::close(tmp_fd);
 		}
 	}
-
-	m_multitype = m_delsys[SYS_DVBS] && (m_delsys[SYS_DVBT] || m_delsys[SYS_DVBC_ANNEX_A]);
-
-	if (!m_multitype)
-		m_type = feSatellite;
-
-	setTone(iDVBFrontend::toneOff);
+	m_multitype = (
+		m_delsys[SYS_DVBS] && m_delsys[SYS_DVBT])
+#if DVB_API_VERSION > 5 || DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 6
+		|| (m_delsys[SYS_DVBC_ANNEX_A] && m_delsys[SYS_DVBS])
+		|| (m_delsys[SYS_DVBC_ANNEX_A] && m_delsys[SYS_DVBT]);
+#else
+		|| (m_delsys[SYS_DVBC_ANNEX_AC] && m_delsys[SYS_DVBS])
+		|| (m_delsys[SYS_DVBC_ANNEX_AC] && m_delsys[SYS_DVBT]);
+#endif
+	if(!m_multitype)
+	{
+		if(m_delsys[SYS_DVBS])
+			m_type = feSatellite;
+		else if(m_delsys[SYS_DVBT])
+			m_type = feTerrestrial;
+#if DVB_API_VERSION > 5 || DVB_API_VERSION == 5 && DVB_API_VERSION_MINOR >= 6
+		else if(m_delsys[SYS_DVBC_ANNEX_A])
+#else
+		else if(m_delsys[SYS_DVBC_ANNEX_AC])
+#endif
+			m_type = feCable;
+		else if(m_delsys[SYS_ATSC])
+			m_type = feATSC;
+	}
+	if(m_type == feSatellite)
+		setTone(iDVBFrontend::toneOff);
 	setVoltage(iDVBFrontend::voltageOff);
-	m_voltage5_terrestrial = -1;
 
 	return 0;
 }
@@ -2611,13 +2649,12 @@ RESULT eDVBFrontend::prepare_sat(const eDVBFrontendParametersSatellite &feparm, 
 			feparm.pls_code,
 			feparm.t2mi_plp_id,
 			feparm.t2mi_pid);
-		if ((unsigned int)satfrequency < (fe_info.type ? fe_info.frequency_min/1000 : fe_info.frequency_min)
-			|| (unsigned int)satfrequency > (fe_info.type ? fe_info.frequency_max/1000 : fe_info.frequency_max))
+		if ((unsigned int)satfrequency < m_fe_info[SYS_DVBS].frequency_min || (unsigned int)satfrequency > m_fe_info[SYS_DVBS].frequency_max)
 		{
-			eDebugNoSimulate("[eDVBFrontend%d] %d mhz out of tuner range.. dont tune", m_dvbid, satfrequency / 1000);
+			eDebugNoSimulate("%d MHz out of tuner range.. dont tune (min: %d MHz max: %d MHz)", satfrequency / 1000, m_fe_info[SYS_DVBS].frequency_min/1000, m_fe_info[SYS_DVBS].frequency_max/1000);
 			return -EINVAL;
 		}
-		eDebugNoSimulate("[eDVBFrontend%d] tuning to %d mhz", m_dvbid, satfrequency / 1000);
+		eDebugNoSimulate("tuning to %d MHz", satfrequency / 1000);
 	}
 	oparm.setDVBS(feparm, feparm.no_rotor_command_on_tune);
 	return res;
@@ -3149,6 +3186,7 @@ int eDVBFrontend::isCompatibleWith(ePtr<iDVBFrontendParameters> &feparm, bool is
 bool eDVBFrontend::supportsDeliverySystem(const fe_delivery_system_t &sys, bool obeywhitelist)
 {
 	std::map<fe_delivery_system_t, bool>::iterator it = m_delsys.find(sys);
+
 	if (it != m_delsys.end() && it->second)
 	{
 		if (obeywhitelist && !m_delsys_whitelist.empty())

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -569,7 +569,7 @@ int eDVBFrontend::PreferredFrontendIndex = -1;
 eDVBFrontend::eDVBFrontend(const char *devicenodename, int fe, int &ok, bool simulate, eDVBFrontend *simulate_fe)
 	:m_simulate(simulate), m_enabled(false), m_fbc(false), m_is_usbtuner(false), m_simulate_fe(simulate_fe), m_type(-1), m_dvbid(fe), m_slotid(fe)
 	,m_fd(-1), m_dvbversion(0), m_rotor_mode(false), m_need_rotor_workaround(false), m_multitype(false), m_voltage5_terrestrial(-1)
-	,m_state(stateClosed), m_timeout(0), m_tuneTimer(0)
+	,m_state(stateClosed), m_timeout(0), m_tuneTimer(0), m_configRetuneNoPatEntry(0)
 {
 	m_filename = devicenodename;
 
@@ -902,10 +902,33 @@ void eDVBFrontend::timeout()
 	m_tuning = 0;
 	if (m_state == stateTuning)
 	{
-		m_state = stateFailed;
-		m_data[CSW] = m_data[UCSW] = m_data[TONEBURST] = -1; // reset diseqc
-		m_stateChanged(this);
+		retune();
 	}
+}
+
+void eDVBFrontend::setConfigRetuneNoPatEntry(int value)
+{
+	eDebug("[eDVBFrontend::setConfigRetuneNoPatEntry] %d",value);
+	m_configRetuneNoPatEntry = value;
+}
+
+void eDVBFrontend::checkRetune()
+{
+	if (m_configRetuneNoPatEntry)
+	{
+		eDebug("[eDVBFrontend] start retune after tune error 3 (noPatEntry)");
+		retune();
+	}
+	else
+		eDebug("[eDVBFrontend] not retuning after tune error 3 (noPatEntry) - disabled");
+}
+
+void eDVBFrontend::retune()
+{
+	m_timeout->stop();
+	m_state = stateFailed;
+	m_data[CSW] = m_data[UCSW] = m_data[TONEBURST] = -1; // reset diseqc
+	m_stateChanged(this);
 }
 
 #define INRANGE(X,Y,Z) (((X<=Y) && (Y<=Z))||((Z<=Y) && (Y<=X)) ? 1 : 0)

--- a/lib/dvb/frontend.cpp
+++ b/lib/dvb/frontend.cpp
@@ -29,6 +29,20 @@
 #endif
 #endif
 
+#define ioctlMeasureStart \
+	struct timeval start, end; \
+	int duration; \
+	if (m_debuglevel==5) { gettimeofday(&start, NULL); }
+
+#define ioctlMeasureEval(x) \
+	do { \
+		if (m_debuglevel==5) { \
+			gettimeofday(&end, NULL); \
+			duration = (((end.tv_usec - start.tv_usec)/1000) + 1000 ) % 1000; \
+			if (duration>35) { eWarning("[eDVBFrontend] Slow ioctl '%s', potential driver issue, %dms",x,duration); } \
+		} \
+	} while(0)
+
 #define eDebugNoSimulate(x...) \
 	do { \
 		if (!m_simulate) \
@@ -571,6 +585,7 @@ eDVBFrontend::eDVBFrontend(const char *devicenodename, int fe, int &ok, bool sim
 	,m_fd(-1), m_dvbversion(0), m_rotor_mode(false), m_need_rotor_workaround(false), m_multitype(false), m_voltage5_terrestrial(-1)
 	,m_state(stateClosed), m_timeout(0), m_tuneTimer(0), m_configRetuneNoPatEntry(0)
 {
+	m_debuglevel = eGetEnigmaDebugLvl();
 	m_filename = devicenodename;
 
 	m_timeout = eTimer::create(eApp);
@@ -627,11 +642,14 @@ int eDVBFrontend::openFrontend()
 			cmdseq.props = &p;
 			cmdseq.num = 1;
 			p.cmd = DTV_API_VERSION;
+			ioctlMeasureStart;
 			if (ioctl(m_fd, FE_GET_PROPERTY, &cmdseq) >= 0)
 			{
 				m_dvbversion = p.u.data;
-				eDebug("[eDVBFrontend%d] frontend %d has DVB API %02x ", m_dvbid, m_dvbid, m_dvbversion);
 			}
+			else
+				eWarning("[eDVBFrontend] ioctl FE_GET_PROPERTY/DTV_API_VERSION failed: %m");
+			ioctlMeasureEval("FE_GET_PROPERTY(DTV_API_VERSION)");
 #endif
 		}
 		if (m_delsys.empty())
@@ -650,16 +668,24 @@ int eDVBFrontend::openFrontend()
 			struct dtv_properties cmdseq = {};
 			cmdseq.num = 1;
 			cmdseq.props = p;
+			ioctlMeasureStart;
 			if (::ioctl(m_fd, FE_GET_PROPERTY, &cmdseq) >= 0)
 			{
+				ioctlMeasureEval("FE_GET_PROPERTY(DTV_ENUM_DELSYS)");
 				m_delsys.clear();
 				for (; p[0].u.buffer.len > 0; p[0].u.buffer.len--)
 				{
 					fe_delivery_system_t delsys = (fe_delivery_system_t)p[0].u.buffer.data[p[0].u.buffer.len - 1];
 					m_delsys[delsys] = true;
+					setDeliverySystem(delsys);
+					if (::ioctl(m_fd, FE_GET_INFO, &m_fe_info[delsys]) < 0)
+						eWarning("[eDVBFrontend] ioctl FE_GET_INFO failed: %m");
 				}
+				ioctlMeasureEval("DTV_ENUM_DELSYS");
 			}
 			else
+			{
+				eWarning("[eDVBFrontend] ioctl FE_GET_PROPERTY/DTV_ENUM_DELSYS failed: %m");
 #else
 			/* no DTV_ENUM_DELSYS support */
 			if (1)
@@ -1458,8 +1484,10 @@ int eDVBFrontend::readFrontendData(int type)
 				uint16_t snr = 0;
 				if (!m_simulate)
 				{
+					ioctlMeasureStart;
 					if (ioctl(m_fd, FE_READ_SNR, &snr) < 0 && errno != ERANGE)
-						eDebug("[eDVBFrontend] FE_READ_SNR failed: %m");
+						eDebug("[eDVBFrontend] FE_READ_SNR failed (%m)");
+					ioctlMeasureEval("FE_READ_SNR");
 				}
 				return snr;
 			}
@@ -1541,12 +1569,14 @@ int eDVBFrontend::readFrontendData(int type)
 						props.props = prop;
 						props.num = 1;
 
+						ioctlMeasureStart;
 						if (::ioctl(m_fd, FE_GET_PROPERTY, &props) < 0 && errno != ERANGE)
 						{
 							eDebug("[eDVBFrontend] DTV_STAT_SIGNAL_STRENGTH failed: %m");
 						}
 						else
 						{
+							ioctlMeasureEval("FE_GET_PROPERTY(DTV_STAT_SIGNAL_STRENGTH)");
 							for(unsigned int i=0; i<prop[0].u.st.len; i++)
 							{
 								if (prop[0].u.st.stat[i].scale == FE_SCALE_RELATIVE)
@@ -1556,8 +1586,10 @@ int eDVBFrontend::readFrontendData(int type)
 					}
 #endif
 					// fallback to old DVB API
+					ioctlMeasureStart;
 					if (!strength && ioctl(m_fd, FE_READ_SIGNAL_STRENGTH, &strength) < 0 && errno != ERANGE)
-						eDebug("[eDVBFrontend] FE_READ_SIGNAL_STRENGTH failed: %m");
+						eDebug("[eDVBFrontend] FE_READ_SIGNAL_STRENGTH failed (%m)");
+					ioctlMeasureEval("FE_READ_SIGNAL_STRENGTH");
 				}
 				return strength;
 			}
@@ -1575,8 +1607,10 @@ int eDVBFrontend::readFrontendData(int type)
 			fe_status_t status;
 			if (!m_simulate)
 			{
+				ioctlMeasureStart;
 				if ( ioctl(m_fd, FE_READ_STATUS, &status) < 0 && errno != ERANGE )
-					eDebug("[eDVBFrontend] FE_READ_STATUS failed: %m");
+					eDebug("[eDVBFrontend] FE_READ_STATUS failed (%m)");
+				ioctlMeasureEval("FE_READ_STATUS");
 				return (int)status;
 			}
 			return (FE_HAS_SYNC | FE_HAS_LOCK);
@@ -1589,10 +1623,13 @@ int eDVBFrontend::readFrontendData(int type)
 			cmdseq.props = &p;
 			cmdseq.num = 1;
 			p.cmd = DTV_FREQUENCY;
+			ioctlMeasureStart;
 			if (ioctl(m_fd, FE_GET_PROPERTY, &cmdseq) < 0)
 			{
+				ioctlMeasureEval("FE_GET_PROPERTY(DTV_FREQUENCY)");
 				return 0;
 			}
+			ioctlMeasureEval("FE_GET_PROPERTY(DTV_FREQUENCY)");
 			return type == feSatellite ? p.u.data + m_data[FREQ_OFFSET] : p.u.data;
 		}
 	}
@@ -1655,11 +1692,13 @@ void eDVBFrontend::getTransponderData(ePtr<iDVBTransponderData> &dest, bool orig
 		else if (type == feATSC)
 		{
 		}
+		ioctlMeasureStart;
 		if (ioctl(m_fd, FE_GET_PROPERTY, &cmdseq) < 0)
 		{
-			eDebug("[eDVBFrontend] FE_GET_PROPERTY failed: %m");
+			eDebug("[eDVBFrontend] FE_GET_PROPERTY failed (%m)");
 			original = true;
 		}
+		ioctlMeasureEval("FE_GET_PROPERTY(&cmdseq)");
 	}
 	switch (type)
 	{

--- a/lib/dvb/frontend.h
+++ b/lib/dvb/frontend.h
@@ -161,6 +161,9 @@ public:
 	RESULT setSecSequence(eSecCommandList &list);
 	RESULT getData(int num, long &data);
 	RESULT setData(int num, long val);
+	void checkRetune();
+	void retune();
+	void setConfigRetuneNoPatEntry(int value);
 
 	int readFrontendData(int type); // iFrontendInformation_ENUMS
 	void getFrontendStatus(ePtr<iDVBFrontendStatus> &dest);

--- a/lib/dvb/frontend.h
+++ b/lib/dvb/frontend.h
@@ -128,6 +128,8 @@ private:
 
 	int m_timeoutCount; // needed for timeout
 	int m_retryCount; // diseqc retry for rotor
+	int m_configRetuneNoPatEntry;
+	int m_debuglevel;
 
 	void feEvent(int);
 	void timeout();

--- a/lib/dvb/idvb.h
+++ b/lib/dvb/idvb.h
@@ -83,6 +83,8 @@ struct eBouquet
 	'explicit' doesn't here - eTransportStreamID(eOriginalNetworkID(n))
 	would still work. */
 
+#endif // SWIG
+
 struct eTransportStreamID
 {
 private:
@@ -197,6 +199,46 @@ public:
 
 	};
 
+	// Service types (data[ref_service_type])
+	enum {
+		invalid             = -1,
+				      //0x00, //  0             reserved for future use
+		dTv                 = 0x01, //  1             digital television service (see note 1)
+		dRadio              = 0x02, //  2             digital radio sound service (see note 2)
+		tText               = 0x03, //  3             Teletext service
+		nvod                = 0x04, //  4             NVOD reference service (see note 1)
+		nvodTs              = 0x05, //  5             NVOD time - shifted service (see note 1)
+		mosaic              = 0x06, //  6             mosaic service
+		radioFm             = 0x07, //  7             FM radio service
+		dvbSrm              = 0x08, //  8             DVB SRM service
+				      //0x09, //  9             reserved for future use
+		dRadioAvc           = 0x0A, // 10             advanced codec digital radio sound service
+		mosaicAvc           = 0x0B, // 11             H.264/AVC mosaic service
+		datacast            = 0x0C, // 12             data broadcast service
+		ci                  = 0x0D, // 13             reserved for Common Interface Usage (EN 50221)
+		rcsMap              = 0x0E, // 14             RCS Map (see EN 301 790)
+		rcsFls              = 0x0F, // 15             RCS FLS (see EN 301 790)
+		dvbMhp              = 0x10, // 16             DVB MHP service
+		mpeg2HdTv           = 0x11, // 17             MPEG-2 HD digital television service
+				      //0x12, 18 to 0x15, 21   reserved for future use
+		avcSdTv             = 0x16, // 22             H.264/AVC SD digital television service
+		nvodAvcSdTs         = 0x17, // 23             H.264/AVC SD NVOD time - shifted service
+		nvodAvcSdRef        = 0x18, // 24             H.264/AVC SD NVOD reference service
+		avcHdTv             = 0x19, // 25             H.264/AVC HD digital television service
+		nvodAvcHdTs         = 0x1A, // 26             H.264/AVC HD NVOD time - shifted service
+		nvodAvcHdRef        = 0x1B, // 27             H.264/AVC HD NVOD reference service
+		avcHdStereo         = 0x1C, // 28             H.264/AVC frame compatible plano - stereoscopic HD digital television service (see note 3)
+		nvodAvcHdStereoTs   = 0x1D, // 29             H.264/AVC frame compatible plano - stereoscopic HD NVOD time - shifted service (see note 3)
+		nvodAvcHdStereoRef  = 0x1E, // 30             H.264/AVC frame compatible plano - stereoscopic HD NVOD reference service (see note 3)
+		nvecTv              = 0x1F, // 31             HEVC digital television service (see note 4) 
+		nvecTv20            = 0x20, // 32             HEVC UHD digital television service with HDR and/or a frame rate of 100 Hz, 120 000/1 001 Hz, or 120 Hz, or any combination of HDR and these frame rates (see note 5) 
+				    //0x21, // 33 to 0x7F/127 reserved for future use
+				    //0x80, //128 to 0xFE/254 user defined
+		user134             = 0x86, //134             ???
+		user195             = 0xC3, //195             ???
+				    //0xFF, //255            reserved for future use
+	};
+
 	int getServiceType() const { return data[ref_service_type]; }
 	void setServiceType(int service_type) { data[ref_service_type]=service_type; }
 
@@ -236,7 +278,7 @@ public:
 	}
 
 	eServiceReferenceDVB(eDVBNamespace dvbnamespace, eTransportStreamID transport_stream_id, eOriginalNetworkID original_network_id, eServiceID service_id, int service_type, int source_id = 0)
-		:eServiceReference(eServiceReference::idDVB, 0)
+		:eServiceReference(eServiceReference::idDVB, eServiceReference::noFlags)
 	{
 		setTransportStreamID(transport_stream_id);
 		setOriginalNetworkID(original_network_id);
@@ -277,7 +319,7 @@ public:
 	}
 
 	eServiceReferenceDVB()
-		:eServiceReference(eServiceReference::idDVB, 0)
+		:eServiceReference(eServiceReference::idDVB, eServiceReference::noFlags)
 	{
 	}
 
@@ -287,6 +329,7 @@ public:
 	}
 };
 
+#ifndef SWIG
 
 ////////////////// TODO: we need an interface here, but what exactly?
 
@@ -306,16 +349,20 @@ public:
 	{
 		cVPID, cMPEGAPID, cTPID, cPCRPID, cAC3PID,
 		cVTYPE, cACHANNEL, cAC3DELAY, cPCMDELAY,
-		cSUBTITLE, cAACHEAPID=12, cDDPPID, cAACAPID,
+		cSUBTITLE, cAACHEAPID=12, cDDPPID, cDTSPID, cAACAPID,
+		cLPCMPID, cDTSHDPID,
 		cDATAPID, cPMTPID, cDRAAPID, cAC4PID, cacheMax
 	};
 
+	static const cacheID audioCacheTags[];
+	static const int nAudioCacheTags;
 	std::string m_reference_str;
 	int getCacheEntry(cacheID);
 	void setCacheEntry(cacheID, int);
 	void setServiceRef(std::string sref) { m_reference_str = sref; }
 
 	bool cacheEmpty();
+	bool cacheAudioEmpty();
 
 	eDVBService();
 	/* m_service_name_sort is uppercase, with special chars removed, to increase sort performance. */

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -390,13 +390,11 @@ void eDVBServicePMTHandler::getCaIds(std::vector<int> &caids, std::vector<int> &
 int eDVBServicePMTHandler::getProgramInfo(program &program)
 {
 	ePtr<eTable<ProgramMapSection> > ptr;
-	int cached_apid_ac3 = -1;
-	int cached_apid_ac4 = -1;
-	int cached_apid_ddp = -1;
-	int cached_apid_mpeg = -1;
-	int cached_apid_aache = -1;
-	int cached_apid_aac = -1;
-	int cached_apid_dra = -1;
+	struct audioMap {
+		int streamType;
+		eDVBService::cacheID cacheTag;
+	};
+	int cached_apid[eDVBService::cacheMax];
 	int cached_vpid = -1;
 	int cached_tpid = -1;
 	int ret = -1;
@@ -410,16 +408,17 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 
 	eDVBPMTParser::clearProgramInfo(program);
 
+	for (int m = 0; m < eDVBService::cacheMax; m++)
+		cached_apid[m] = -1;
+
 	if ( m_service && !m_service->cacheEmpty() )
 	{
 		cached_vpid = m_service->getCacheEntry(eDVBService::cVPID);
-		cached_apid_mpeg = m_service->getCacheEntry(eDVBService::cMPEGAPID);
-		cached_apid_ac3 = m_service->getCacheEntry(eDVBService::cAC3PID);
-		cached_apid_ac4 = m_service->getCacheEntry(eDVBService::cAC4PID);
-		cached_apid_ddp = m_service->getCacheEntry(eDVBService::cDDPPID);
-		cached_apid_aache = m_service->getCacheEntry(eDVBService::cAACHEAPID);
-		cached_apid_aac = m_service->getCacheEntry(eDVBService::cAACAPID);
-		cached_apid_dra = m_service->getCacheEntry(eDVBService::cDRAAPID);
+		for (int m = 0; m < eDVBService::nAudioCacheTags; m++)
+		{
+			eDVBService::cacheID cTag = eDVBService::audioCacheTags[m];
+			cached_apid[cTag] = m_service->getCacheEntry(cTag);
+		}
 		cached_tpid = m_service->getCacheEntry(eDVBService::cTPID);
 	}
 
@@ -427,16 +426,25 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 	{
 		unsigned int i;
 		int first_non_mpeg = -1;
-		int first_mpeg = -1;
 		int audio_cached = -1;
-		int autoaudio_mpeg = -1;
-		int autoaudio_ac3 = -1;
-		int autoaudio_ac4 = -1;
-		int autoaudio_ddp = -1;
-		int autoaudio_aache = -1;
-		int autoaudio_aac = -1;
-		int autoaudio_dra = -1;
+		int autoaudio[eDVBService::cacheMax];
 		int autoaudio_level = 4;
+		const static audioMap audioMapMain[] = {
+			{ audioStream::atMPEG,  eDVBService::cMPEGAPID,  },
+			{ audioStream::atAC3,   eDVBService::cAC3PID,    },
+			{ audioStream::atAC4,    eDVBService::cAC4PID,   },
+			{ audioStream::atDDP,   eDVBService::cDDPPID,    },
+			{ audioStream::atAACHE,	eDVBService::cAACHEAPID, },
+			{ audioStream::atAAC,   eDVBService::cAACAPID,   },
+			{ audioStream::atDTS,   eDVBService::cDTSPID,    },
+			{ audioStream::atLPCM,  eDVBService::cLPCMPID,   },
+			{ audioStream::atDTSHD, eDVBService::cDTSHDPID,  },
+			{ audioStream::atDRA,    eDVBService::cDRAAPID,  },
+		};
+		static const int nAudioMapMain = sizeof audioMapMain / sizeof audioMapMain[0];
+
+		for (int m = 0; m < eDVBService::cacheMax; m++)
+			autoaudio[m] = -1;
 
 		std::string configvalue;
 		std::vector<std::string> autoaudio_languages;
@@ -493,29 +501,33 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 				break;
 			}
 		}
-		for (i = 0; i < program.audioStreams.size(); i++)
+		i = 0;
+		for (std::vector<audioStream>::const_iterator
+			as(program.audioStreams.begin());
+			as != program.audioStreams.end(); ++as, ++i)
 		{
-			if (program.audioStreams[i].pid == cached_apid_ac3
-			 || program.audioStreams[i].pid == cached_apid_ac4
-			 || program.audioStreams[i].pid == cached_apid_ddp
-			 || program.audioStreams[i].pid == cached_apid_mpeg
-			 || program.audioStreams[i].pid == cached_apid_aache
-			 || program.audioStreams[i].pid == cached_apid_aac
-			 || program.audioStreams[i].pid == cached_apid_dra)
+			for (int m = 0; m < eDVBService::nAudioCacheTags; m++)
 			{
-				/* if we find the cached pids, this will be our default stream */
-				audio_cached = i;
+				eDVBService::cacheID cTag = eDVBService::audioCacheTags[m];
+				if (as->pid == cached_apid[cTag])
+					/* if we find the cached pids, this will be our default stream */
+
+					audio_cached = i;
+					break;
 			}
 			/* also, we need to know the first non-mpeg (i.e. "ac3"/dts/...) stream */
-			if ((program.audioStreams[i].type != audioStream::atMPEG) && ((first_non_mpeg == -1)
-				|| (program.audioStreams[i].pid == cached_apid_ac3)
-				|| (program.audioStreams[i].pid == cached_apid_ac4)
-				|| (program.audioStreams[i].pid == cached_apid_ddp)
-				|| (program.audioStreams[i].pid == cached_apid_aache)
-				|| (program.audioStreams[i].pid == cached_apid_aac)
-				|| (program.audioStreams[i].pid == cached_apid_dra)))
-			{
-				first_non_mpeg = i;
+			if (as->type != audioStream::atMPEG) {
+				if (first_non_mpeg == -1)
+					first_non_mpeg = i;
+				else
+				{
+					for (int m = 0; m < eDVBService::nAudioCacheTags; m++)
+					{
+						if (as->pid == cached_apid[eDVBService::audioCacheTags[m]])
+							first_non_mpeg = i;
+							break;
+					}
+				}
 			}
 
 			if (autoaudio_languages.empty() && program.audioStreams[i].type == audioStream::atMPEG && first_mpeg == -1)
@@ -523,10 +535,12 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 				first_mpeg = i;
 			}
 
-			if (!program.audioStreams[i].language_code.empty())
+			if (!as->language_code.empty())
 			{
 				int x = 1;
-				for (std::vector<std::string>::iterator it = autoaudio_languages.begin();x <= autoaudio_level && it != autoaudio_languages.end();x++,it++)
+				for (std::vector<std::string>::iterator
+					it = autoaudio_languages.begin();
+					x <= autoaudio_level && it != autoaudio_languages.end(); x++, it++)
 				{
 					bool languageFound = false;
 					size_t pos = 0;
@@ -535,25 +549,20 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 					audioStreamLanguages += delimiter;
 					while ((pos = audioStreamLanguages.find(delimiter)) != std::string::npos)
 					{
-						if ((*it).find(audioStreamLanguages.substr(0, pos)) != std::string::npos)
+						if ((*it).find(as->language_code) != std::string::npos)
 						{
-							if (program.audioStreams[i].type == audioStream::atMPEG && (autoaudio_level > x || autoaudio_mpeg == -1))
-								autoaudio_mpeg = i;
-							else if (program.audioStreams[i].type == audioStream::atAC3 && (autoaudio_level > x || autoaudio_ac3 == -1))
-								autoaudio_ac3 = i;
-							else if (program.audioStreams[i].type == audioStream::atAC4 && (autoaudio_level > x || autoaudio_ac4 == -1))
-								autoaudio_ac4 = i;
-							else if (program.audioStreams[i].type == audioStream::atDDP && (autoaudio_level > x || autoaudio_ddp == -1))
-								autoaudio_ddp = i;
-							else if (program.audioStreams[i].type == audioStream::atAACHE && (autoaudio_level > x || autoaudio_aache == -1))
-								autoaudio_aache = i;
-							else if (program.audioStreams[i].type == audioStream::atAAC && (autoaudio_level > x || autoaudio_aac == -1))
-								autoaudio_aac = i;
-							else if (program.audioStreams[i].type == audioStream::atDRA && (autoaudio_level > x || autoaudio_dra == -1))
-								autoaudio_dra = i;
-							autoaudio_level = x;
-							languageFound = true;
-							break;
+						for (int m = 0; m < nAudioMapMain; m++)
+						{
+							eDVBService::cacheID cTag = audioMapMain[m].cacheTag;
+							if (as->type == audioMapMain[m].streamType && (autoaudio_level > x || autoaudio[cTag] == -1))
+							{
+								autoaudio[cTag] = i;
+								break;
+							}
+						}
+						autoaudio_level = x;
+						languageFound = true;
+						break;
 						}
 						audioStreamLanguages.erase(0, pos + 1);
 					}
@@ -562,20 +571,25 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 				}
 			}
 		}
-		for (i = 0; i < program.subtitleStreams.size(); i++)
+		i = 0;
+		for (std::vector<subtitleStream>::const_iterator
+			ss(program.subtitleStreams.begin());
+			ss != program.subtitleStreams.end(); ++ss, ++i)
 		{
-			if (!program.subtitleStreams[i].language_code.empty())
+			if (!ss->language_code.empty())
 			{
 				int x = 1;
-				for (std::vector<std::string>::iterator it2 = autosub_languages.begin();x <= autosub_level && it2 != autosub_languages.end();x++,it2++)
+				for (std::vector<std::string>::iterator
+					it2 = autosub_languages.begin();
+					x <= autosub_level && it2 != autosub_languages.end(); x++, it2++)
 				{
 					if ((*it2).find(program.subtitleStreams[i].language_code) != std::string::npos)
 					{
 						autosub_level = x;
-						if (program.subtitleStreams[i].subtitling_type >= 0x10)
+						if (ss->subtitling_type >= 0x10)
 						{
 							/* DVB subs */
-							if (program.subtitleStreams[i].subtitling_type >= 0x20)
+							if (ss->subtitling_type >= 0x20)
 								autosub_dvb_hearing = i;
 							else
 								autosub_dvb_normal = i;
@@ -583,7 +597,7 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 						else
 						{
 							/* TXT subs */
-							if (program.subtitleStreams[i].subtitling_type == 0x05)
+							if (ss->subtitling_type == 0x05)
 								autosub_txt_hearing = i;
 							else
 								autosub_txt_normal = i;
@@ -600,28 +614,26 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 
 		if (useaudio_cache && audio_cached != -1)
 			program.defaultAudioStream = audio_cached;
-		else if (defaultac3 && autoaudio_ac3 != -1)
-			program.defaultAudioStream = autoaudio_ac3;
-		else if (defaultddp && autoaudio_ddp != -1)
-			program.defaultAudioStream = autoaudio_ddp;
+		else if (defaultac3 && autoaudio[eDVBService::cAC3PID] != -1)
+			program.defaultAudioStream = autoaudio[eDVBService::cAC3PID];
+		else if (defaultddp && autoaudio[eDVBService::cDDPPID] != -1)
+			program.defaultAudioStream = autoaudio[eDVBService::cDDPPID];
 		else
 		{
-			if (autoaudio_mpeg != -1)
-				program.defaultAudioStream = autoaudio_mpeg;
-			else if (autoaudio_ac3 != -1)
-				program.defaultAudioStream = autoaudio_ac3;
-			else if (autoaudio_ac4 != -1)
-				program.defaultAudioStream = autoaudio_ac4;
-			else if (autoaudio_ddp != -1)
-				program.defaultAudioStream = autoaudio_ddp;
-			else if (autoaudio_aache != -1)
-				program.defaultAudioStream = autoaudio_aache;
-			else if (autoaudio_aac != -1)
-				program.defaultAudioStream = autoaudio_aac;
+			int defaultAudio = -1;
+			for (int m = 0; m < nAudioMapMain; m++)
+			{
+				eDVBService::cacheID cTag = audioMapMain[m].cacheTag;
+				if (autoaudio[cTag] != -1)
+				{
+					defaultAudio = autoaudio[cTag];
+					break;
+				}
+			}
+			if (defaultAudio != -1)
+				program.defaultAudioStream = defaultAudio;
 			else if (first_non_mpeg != -1 && (defaultac3 || defaultddp))
 				program.defaultAudioStream = first_non_mpeg;
-			else if (first_non_mpeg != -1 && first_mpeg != -1 && first_non_mpeg < first_mpeg && (!defaultac3 || !defaultddp))
-				program.defaultAudioStream = first_mpeg;
 		}
 
 		bool allow_hearingimpaired = eSubtitleSettings::subtitle_hearingimpaired;
@@ -666,6 +678,20 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 	}
 	else if ( m_service && !m_service->cacheEmpty() )
 	{
+		// Same entries, but different order from audioMapMain
+		const static audioMap audioMapList[] = {
+			{ audioStream::atAC3,   eDVBService::cAC3PID,    },
+			{ audioStream::atAC4,   eDVBService::cAC4PID,    },
+			{ audioStream::atDDP,   eDVBService::cDDPPID,    },
+			{ audioStream::atAAC,   eDVBService::cAACAPID,   },
+			{ audioStream::atDTS,   eDVBService::cDTSPID,    },
+			{ audioStream::atLPCM,  eDVBService::cLPCMPID,   },
+			{ audioStream::atDTSHD, eDVBService::cDTSHDPID,  },
+			{ audioStream::atAACHE, eDVBService::cAACHEAPID, },
+			{ audioStream::atDRA,   eDVBService::cDRAAPID,   },
+			{ audioStream::atMPEG,  eDVBService::cMPEGAPID,  },
+		};
+		static const int nAudioMapList = sizeof audioMapList / sizeof audioMapList[0];
 		int cached_pcrpid = m_service->getCacheEntry(eDVBService::cPCRPID),
 			vpidtype = m_service->getCacheEntry(eDVBService::cVTYPE),
 			pmtpid = m_service->getCacheEntry(eDVBService::cPMTPID),
@@ -688,68 +714,18 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 			program.videoStreams.push_back(s);
 			++cnt;
 		}
-		if ( cached_apid_ac3 != -1 )
+		for (int m = 0; m < nAudioMapList; m++)
 		{
-			audioStream s = {};
-			s.type = audioStream::atAC3;
-			s.pid = cached_apid_ac3;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
-		}
-		if ( cached_apid_ac4 != -1 )
-		{
-			audioStream s = {};
-			s.type = audioStream::atAC4;
-			s.pid = cached_apid_ac4;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
-		}
-		if ( cached_apid_ddp != -1 )
-		{
-			audioStream s = {};
-			s.type = audioStream::atDDP;
-			s.pid = cached_apid_ddp;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
-		}
-		if ( cached_apid_aache != -1 )
-		{
-			audioStream s = {};
-			s.type = audioStream::atAACHE;
-			s.pid = cached_apid_aache;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
-		}
-		if ( cached_apid_aac != -1 )
-		{
-			audioStream s = {};
-			s.type = audioStream::atAAC;
-			s.pid = cached_apid_aac;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
-		}
-		if ( cached_apid_dra != -1 )
-		{
-			audioStream s = {};
-			s.type = audioStream::atDRA;
-			s.pid = cached_apid_dra;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
-		}
-		if ( cached_apid_mpeg != -1 )
-		{
-			audioStream s = {};
-			s.type = audioStream::atMPEG;
-			s.pid = cached_apid_mpeg;
-			s.rdsPid = -1;
-			program.audioStreams.push_back(s);
-			++cnt;
+			eDVBService::cacheID cTag = audioMapList[m].cacheTag;
+			if (cached_apid[cTag] != -1)
+			{
+				audioStream s;
+				s.type = audioMapList[m].streamType;
+				s.pid = cached_apid[cTag];
+				s.rdsPid = -1;
+				program.audioStreams.push_back(s);
+				++cnt;
+			}
 		}
 		if ( cached_pcrpid != -1 )
 		{
@@ -763,7 +739,7 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 		}
 		if (subpid > 0)
 		{
-			subtitleStream s = {};
+			subtitleStream s;
 			s.pid = (subpid & 0xffff0000) >> 16;
 			if (s.pid != program.textPid)
 			{

--- a/lib/dvb/pmt.cpp
+++ b/lib/dvb/pmt.cpp
@@ -25,11 +25,14 @@
 #include <dvbsi++/simple_application_boundary_descriptor.h>
 #include <dvbsi++/transport_protocol_descriptor.h>
 #include <dvbsi++/application_name_descriptor.h>
+#include <dvbsi++/application_profile.h>
+#include <dvbsi++/application_descriptor.h>
 
 int eDVBServicePMTHandler::m_debug = -1;
 
 eDVBServicePMTHandler::eDVBServicePMTHandler()
-	:m_ca_servicePtr(0), m_dvb_scan(0), m_decode_demux_num(0xFF), m_no_pat_entry_delay(eTimer::create())
+	:m_last_channel_state(-1), m_ca_servicePtr(0), m_dvb_scan(0), m_decode_demux_num(0xFF),
+	m_no_pat_entry_delay(eTimer::create()), m_have_cached_program(false)
 {
 	m_use_decode_demux = 0;
 	m_pmt_pid = -1;
@@ -39,6 +42,7 @@ eDVBServicePMTHandler::eDVBServicePMTHandler()
 	m_pmt_ready = false;
 	if(eDVBServicePMTHandler::m_debug < 0)
 		eDVBServicePMTHandler::m_debug = eSimpleConfig::getBool("config.crash.debugDVB", false) ? 1 : 0;
+
 	eDVBResourceManager::getInstance(m_resourceManager);
 	CONNECT(m_PAT.tableReady, eDVBServicePMTHandler::PATready);
 	CONNECT(m_AIT.tableReady, eDVBServicePMTHandler::AITready);
@@ -205,6 +209,13 @@ void eDVBServicePMTHandler::PMTready(int error)
 void eDVBServicePMTHandler::sendEventNoPatEntry()
 {
 	serviceEvent(eventNoPATEntry);
+
+	ePtr<iDVBFrontend> fe;
+	if (!m_channel->getFrontend(fe))
+	{
+		eDVBFrontend *frontend = (eDVBFrontend*)&(*fe);
+		frontend->checkRetune();
+	}
 }
 
 void eDVBServicePMTHandler::PATready(int)
@@ -218,7 +229,11 @@ void eDVBServicePMTHandler::PATready(int)
 		int pmtpid_single = -1;
 		int pmtpid = -1;
 		int cnt=0;
-		std::vector<ProgramAssociationSection*>::const_iterator i;
+		int tsid=-1;
+		std::vector<ProgramAssociationSection*>::const_iterator i = ptr->getSections().begin();
+		tsid = (*i)->getTableIdExtension(); // in PAT this is the transport stream id
+		if(eDVBServicePMTHandler::m_debug)
+			eDebug("[eDVBServicePMTHandler] PAT TSID: 0x%04x (%d)", tsid, tsid);
 		for (i = ptr->getSections().begin(); pmtpid == -1 && i != ptr->getSections().end(); ++i)
 		{
 			const ProgramAssociationSection &pat = **i;
@@ -529,12 +544,6 @@ int eDVBServicePMTHandler::getProgramInfo(program &program)
 					}
 				}
 			}
-
-			if (autoaudio_languages.empty() && program.audioStreams[i].type == audioStream::atMPEG && first_mpeg == -1)
-			{
-				first_mpeg = i;
-			}
-
 			if (!as->language_code.empty())
 			{
 				int x = 1;

--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from os import path
 
 from enigma import eAVControl, eServiceReference, iPlayableService, iServiceInformation
@@ -10,6 +11,50 @@ from Tools.Transponder import ConvertToHumanReadable
 
 MODULE_NAME = __name__.split(".")[-1]
 WIDESCREEN = [1, 3, 4, 7, 8, 11, 12, 15, 16]  # This is imported into InfoBarGenerics.py!
+
+
+def StdAudioDesc(description):
+	if not description:
+		return ""
+
+	REPLACEMENTS = (
+		("A_", ""),
+		("AC-3", "AC3"),
+		("(ATSC A/52)", ""),
+		("(ATSC A/52B)", ""),
+		("MPEG-1 Layer 2 (MP2)", "MP2"),
+		(" Layer 2 (MP2)", ""),
+		(" Layer 3 (MP3)", "MP3"),
+		("-1", ""),
+		("-2", ""),
+		("2-", ""),
+		("MPEG-4 AAC", "AAC"),
+		("-4 AAC", "AAC"),
+		("4-AAC", "HE-AAC"),
+		("audio", ""),
+		("/L3", ""),
+		("/mpeg", "AAC"),
+		("/x-", ""),
+		("raw", "Dolby TrueHD"),
+		("E-AC3", "AC3+"),
+		("EAC3", "AC3+"),
+		("IPCM", "AC3"),
+		("LPCM", "AC3+"),
+		("AAC_PLUS", "AAC+"),
+		("AAC_LATM", "AAC"),
+		("WMA/PRO", "WMA Pro"),
+		("MPEG", "MPEG1 Layer II"),
+		("MPEG1 Layer II AAC", "AAC"),
+		("MPEG1 Layer IIAAC", "AAC"),
+		("MPEG1 Layer IIMP3", "MP3"),
+	)
+
+	for orig, repl in REPLACEMENTS:
+		description = description.replace(orig, repl)
+	return description
+
+def getVideoHeight(info):
+	return info.getInfo(iServiceInformation.sVideoHeight)
 
 
 class ServiceInfo(Converter):
@@ -68,12 +113,11 @@ class ServiceInfo(Converter):
 	VIDEO_INFO_ASPECT = 4
 	VIDEO_INFO_GAMMA = 5
 
-	def __init__(self, argument):
-		Converter.__init__(self, argument)
+	def __init__(self, type):
+		Converter.__init__(self, type)
 		# Poll.__init__(self)
 		# self.poll_interval = 10000
 		# self.poll_enabled = True
-		self.argument = argument
 		self.token, self.interestingEvents = {
 			"AudioPid": (self.APID, (iPlayableService.evUpdatedInfo,)),
 			"AudioTracksAvailable": (self.AUDIOTRACKS_AVAILABLE, (iPlayableService.evUpdatedInfo,)),
@@ -101,14 +145,14 @@ class ServiceInfo(Converter):
 			"IsMultichannel": (self.IS_MULTICHANNEL, (iPlayableService.evUpdatedInfo,)),
 			"IsNotWidescreen": (self.IS_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged,)),
 			"IsSD": (self.IS_SD, (iPlayableService.evVideoSizeChanged,)),
-			# "IsSDAndNotWidescreen": (self.IS_SD_AND_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
-			# "IsSDAndWidescreen": (self.IS_SD_AND_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
+			"IsSDAndNotWidescreen": (self.IS_SD_AND_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
+			"IsSDAndWidescreen": (self.IS_SD_AND_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
 			"IsSDR": (self.IS_SDR, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
 			"IsStereo": (self.IS_STEREO, (iPlayableService.evUpdatedInfo,)),
 			"IsStream": (self.IS_STREAM, (iPlayableService.evUpdatedInfo,)),
-			# "IsVideoAVC": (self.IS_VIDEO_AVC, (iPlayableService.evUpdatedInfo,)),
-			# "IsVideoHEVC": (self.IS_VIDEO_HEVC, (iPlayableService.evUpdatedInfo,)),
-			# "IsVideoMPEG2": (self.IS_VIDEO_MPEG2, (iPlayableService.evUpdatedInfo,)),
+			"IsVideoAVC": (self.IS_VIDEO_AVC, (iPlayableService.evUpdatedInfo,)),
+			"IsVideoHEVC": (self.IS_VIDEO_HEVC, (iPlayableService.evUpdatedInfo,)),
+			"IsVideoMPEG2": (self.IS_VIDEO_MPEG2, (iPlayableService.evUpdatedInfo,)),
 			"IsWidescreen": (self.IS_WIDESCREEN, (iPlayableService.evVideoSizeChanged,)),
 			"OnId": (self.ONID, (iPlayableService.evUpdatedInfo,)),
 			"PcrPid": (self.PCRPID, (iPlayableService.evUpdatedInfo,)),
@@ -125,9 +169,9 @@ class ServiceInfo(Converter):
 			"VideoHeight": (self.YRES, (iPlayableService.evVideoSizeChanged,)),
 			"VideoInfo": (self.VIDEO_INFORMATION, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoFramerateChanged, iPlayableService.evVideoProgressiveChanged, iPlayableService.evUpdatedInfo)),
 			"VideoPid": (self.VPID, (iPlayableService.evUpdatedInfo,)),
-			# "VideoSize": (self.VIDEO_SIZE, (iPlayableService.evVideoSizeChanged,)),
+			"VideoSize": (self.VIDEO_SIZE, (iPlayableService.evVideoSizeChanged,)),
 			"VideoWidth": (self.XRES, (iPlayableService.evVideoSizeChanged,)),
-		}.get(argument)
+		}[type]
 		self.instanceInfoBarSubserviceSelection = None
 
 	@cached

--- a/lib/python/Components/Converter/ServiceInfo.py
+++ b/lib/python/Components/Converter/ServiceInfo.py
@@ -1,308 +1,326 @@
-# -*- coding: utf-8 -*-
-from Components.Converter.Converter import Converter
-from enigma import iServiceInformation, iPlayableService, eServiceReference
-from Screens.InfoBarGenerics import hasActiveSubservicesForCurrentChannel
-from Components.Element import cached
-
 from os import path
 
+from enigma import eAVControl, eServiceReference, iPlayableService, iServiceInformation
 
-WIDESCREEN = [3, 4, 7, 8, 0xB, 0xC, 0xF, 0x10]
+from Components.Element import cached
+from Components.Converter.Converter import Converter
+# from Components.Converter.Poll import Poll
+from Tools.Directories import fileReadLine
+from Tools.Transponder import ConvertToHumanReadable
 
-
-def StdAudioDesc(description):
-	if not description:
-		return ""
-
-	REPLACEMENTS = (
-		("A_", ""),
-		("AC-3", "AC3"),
-		("(ATSC A/52)", ""),
-		("(ATSC A/52B)", ""),
-		("MPEG-1 Layer 2 (MP2)", "MP2"),
-		(" Layer 2 (MP2)", ""),
-		(" Layer 3 (MP3)", "MP3"),
-		("-1", ""),
-		("-2", ""),
-		("2-", ""),
-		("MPEG-4 AAC", "AAC"),
-		("-4 AAC", "AAC"),
-		("4-AAC", "HE-AAC"),
-		("audio", ""),
-		("/L3", ""),
-		("/mpeg", "AAC"),
-		("/x-", ""),
-		("raw", "Dolby TrueHD"),
-		("E-AC3", "AC3+"),
-		("EAC3", "AC3+"),
-		("IPCM", "AC3"),
-		("LPCM", "AC3+"),
-		("AAC_PLUS", "AAC+"),
-		("AAC_LATM", "AAC"),
-		("WMA/PRO", "WMA Pro"),
-		("MPEG", "MPEG1 Layer II"),
-		("MPEG1 Layer II AAC", "AAC"),
-		("MPEG1 Layer IIAAC", "AAC"),
-		("MPEG1 Layer IIMP3", "MP3"),
-	)
-
-	for orig, repl in REPLACEMENTS:
-		description = description.replace(orig, repl)
-	return description
-
-def getVideoHeight(info):
-	return info.getInfo(iServiceInformation.sVideoHeight)
+MODULE_NAME = __name__.split(".")[-1]
+WIDESCREEN = [1, 3, 4, 7, 8, 11, 12, 15, 16]  # This is imported into InfoBarGenerics.py!
 
 
 class ServiceInfo(Converter):
-	HAS_TELETEXT = 0
-	IS_MULTICHANNEL = 1
-	IS_CRYPTED = 2
-	IS_WIDESCREEN = 3
-	SUBSERVICES_AVAILABLE = 4
-	XRES = 5
-	YRES = 6
-	APID = 7
-	VPID = 8
-	PCRPID = 9
-	PMTPID = 10
-	TXTPID = 11
-	TSID = 12
-	ONID = 13
-	SID = 14
-	FRAMERATE = 15
-	TRANSFERBPS = 16
-	HAS_HBBTV = 17
-	AUDIOTRACKS_AVAILABLE = 18
-	SUBTITLES_AVAILABLE = 19
-	EDITMODE = 20
-	IS_STREAM = 21
-	IS_SD = 22
-	IS_HD = 23
-	IS_SD_AND_WIDESCREEN = 24
-	IS_SD_AND_NOT_WIDESCREEN = 25
-	IS_4K = 26
-	IS_STEREO = 27
-	IS_NOT_WIDESCREEN = 28
-	IS_1080 = 29
-	IS_720 = 30
-	IS_SDR = 31
-	IS_HDR = 32
-	IS_HDR10 = 33
-	IS_HLG = 34
-	IS_HDHDR = 35
-	IS_VIDEO_MPEG2 = 36
-	IS_VIDEO_AVC = 37
-	IS_VIDEO_HEVC = 38
+	APID = 0
+	AUDIOTRACKS_AVAILABLE = 1
+	EDITMODE = 2
+	FRAMERATE = 3
+	FREQUENCY_INFORMATION = 4
+	HAS_HBBTV = 5
+	HAS_TELETEXT = 6
+	IS_1080 = 7
+	IS_480 = 8
+	IS_4K = 9
+	IS_576 = 10
+	IS_720 = 11
+	IS_CRYPTED = 12
+	IS_HD = 13
+	IS_HDHDR = 14
+	IS_HDR = 15
+	IS_HDR10 = 16
+	IS_HLG = 17
+	IS_MULTICHANNEL = 18
+	IS_NOT_WIDESCREEN = 19
+	IS_SD = 20
+	IS_SDR = 21
+	IS_SD_AND_NOT_WIDESCREEN = 22
+	IS_SD_AND_WIDESCREEN = 23
+	IS_STEREO = 24
+	IS_STREAM = 25
+	IS_VIDEO_AVC = 26
+	IS_VIDEO_HEVC = 27
+	IS_VIDEO_MPEG2 = 28
+	IS_WIDESCREEN = 29
+	ONID = 30
+	PCRPID = 31
+	PMTPID = 32
+	PROGRESSIVE = 33
+	PROVIDER = 34
+	REFERENCE = 35
+	SID = 36
+	SUBSERVICES_AVAILABLE = 37
+	SUBTITLES_AVAILABLE = 38
+	TRANSFERBPS = 39
+	TSID = 40
+	TXTPID = 41
+	VIDEO_INFORMATION = 42
+	VIDEO_SIZE = 43  # Temporary.
+	VPID = 44
+	XRES = 45
+	YRES = 46
 
-	def __init__(self, type):
-		Converter.__init__(self, type)
-		self.type, self.interesting_events = {
-				"HasTelext": (self.HAS_TELETEXT, (iPlayableService.evUpdatedInfo,)),
-				"IsMultichannel": (self.IS_MULTICHANNEL, (iPlayableService.evUpdatedInfo,)),
-				"IsStereo": (self.IS_STEREO, (iPlayableService.evUpdatedInfo,)),
-				"IsCrypted": (self.IS_CRYPTED, (iPlayableService.evUpdatedInfo,)),
-				"IsWidescreen": (self.IS_WIDESCREEN, (iPlayableService.evVideoSizeChanged,)),
-				"IsNotWidescreen": (self.IS_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged,)),
-				"SubservicesAvailable": (self.SUBSERVICES_AVAILABLE, (iPlayableService.evStart,)),
-				"VideoWidth": (self.XRES, (iPlayableService.evVideoSizeChanged,)),
-				"VideoHeight": (self.YRES, (iPlayableService.evVideoSizeChanged,)),
-				"AudioPid": (self.APID, (iPlayableService.evUpdatedInfo,)),
-				"VideoPid": (self.VPID, (iPlayableService.evUpdatedInfo,)),
-				"PcrPid": (self.PCRPID, (iPlayableService.evUpdatedInfo,)),
-				"PmtPid": (self.PMTPID, (iPlayableService.evUpdatedInfo,)),
-				"TxtPid": (self.TXTPID, (iPlayableService.evUpdatedInfo,)),
-				"TsId": (self.TSID, (iPlayableService.evUpdatedInfo,)),
-				"OnId": (self.ONID, (iPlayableService.evUpdatedInfo,)),
-				"Sid": (self.SID, (iPlayableService.evUpdatedInfo,)),
-				"Framerate": (self.FRAMERATE, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoFramerateChanged, iPlayableService.evUpdatedInfo)),
-				"TransferBPS": (self.TRANSFERBPS, (iPlayableService.evUpdatedInfo)),
-				"HasHBBTV": (self.HAS_HBBTV, (iPlayableService.evUpdatedInfo, iPlayableService.evHBBTVInfo, iPlayableService.evStart)),
-				"AudioTracksAvailable": (self.AUDIOTRACKS_AVAILABLE, (iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-				"SubtitlesAvailable": (self.SUBTITLES_AVAILABLE, (iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-				"Editmode": (self.EDITMODE, (iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-				"IsStream": (self.IS_STREAM, (iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-				"IsSD": (self.IS_SD, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-				"IsHD": (self.IS_HD, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo, iPlayableService.evStart)),
-				"IsSDAndWidescreen": (self.IS_SD_AND_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
-				"IsSDAndNotWidescreen": (self.IS_SD_AND_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
-				"Is4K": (self.IS_4K, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
-				"Is1080": (self.IS_1080, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
-				"Is720": (self.IS_720, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
-				"IsSDR": (self.IS_SDR, (iPlayableService.evVideoGammaChanged, iPlayableService.evUpdatedInfo)),
-				"IsHDR": (self.IS_HDR, (iPlayableService.evVideoGammaChanged, iPlayableService.evUpdatedInfo)),
-				"IsHDR10": (self.IS_HDR10, (iPlayableService.evVideoGammaChanged, iPlayableService.evUpdatedInfo)),
-				"IsHLG": (self.IS_HLG, (iPlayableService.evVideoGammaChanged, iPlayableService.evUpdatedInfo)),
-				"IsVideoMPEG2": (self.IS_VIDEO_MPEG2, (iPlayableService.evUpdatedInfo,)),
-				"IsVideoAVC": (self.IS_VIDEO_AVC, (iPlayableService.evUpdatedInfo,)),
-				"IsVideoHEVC": (self.IS_VIDEO_HEVC, (iPlayableService.evUpdatedInfo,)),
-				"IsHDHDR": (self.IS_HDHDR, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged,)),
-			}[type]
-		if self.type in (self.IS_SD, self.IS_HD, self.IS_SD_AND_WIDESCREEN, self.IS_SD_AND_NOT_WIDESCREEN, self.IS_4K, self.IS_1080, self.IS_720):
-			self.videoHeight = 0
-			if self.type in (self.IS_SD_AND_WIDESCREEN, self.IS_SD_AND_NOT_WIDESCREEN):
-				self.aspect = 0
+	VIDEO_INFO_WIDTH = 0
+	VIDEO_INFO_HEIGHT = 1
+	VIDEO_INFO_FRAME_RATE = 2
+	VIDEO_INFO_PROGRESSIVE = 3
+	VIDEO_INFO_ASPECT = 4
+	VIDEO_INFO_GAMMA = 5
 
-	def isVideoService(self, info):
-		serviceInfo = info.getInfoString(iServiceInformation.sServiceref).split(':')
-		return len(serviceInfo) < 3 or serviceInfo[2] != '2'
-
-	def getServiceInfoString(self, info, what, convert=lambda x: "%d" % x):
-		v = info.getInfo(what)
-		if v == -1:
-			if what == iServiceInformation.sFrameRate and path.isfile("/proc/stb/vmpeg/0/framerate"):
-				try:
-					fps = int(open("/proc/stb/vmpeg/0/framerate").readline().strip())
-				except:
-					fps = 0
-				if fps and isinstance(fps, int):
-					return convert(fps)
-			return _("N/A")
-		if v == -2:
-			return info.getInfoString(what)
-		return convert(v)
+	def __init__(self, argument):
+		Converter.__init__(self, argument)
+		# Poll.__init__(self)
+		# self.poll_interval = 10000
+		# self.poll_enabled = True
+		self.argument = argument
+		self.token, self.interestingEvents = {
+			"AudioPid": (self.APID, (iPlayableService.evUpdatedInfo,)),
+			"AudioTracksAvailable": (self.AUDIOTRACKS_AVAILABLE, (iPlayableService.evUpdatedInfo,)),
+			"EditMode": (self.EDITMODE, (iPlayableService.evUpdatedInfo,)),
+			"Editmode": (self.EDITMODE, (iPlayableService.evUpdatedInfo,)),
+			"FrameRate": (self.FRAMERATE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
+			"Framerate": (self.FRAMERATE, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
+			"FrequencyInfo": (self.FREQUENCY_INFORMATION, (iPlayableService.evUpdatedInfo,)),
+			"Freq_Info": (self.FREQUENCY_INFORMATION, (iPlayableService.evUpdatedInfo,)),
+			"HasHBBTV": (self.HAS_HBBTV, (iPlayableService.evUpdatedInfo, iPlayableService.evHBBTVInfo,)),
+			"HasTeletext": (self.HAS_TELETEXT, (iPlayableService.evUpdatedInfo,)),
+			"HasTelext": (self.HAS_TELETEXT, (iPlayableService.evUpdatedInfo,)),
+			"Is1080": (self.IS_1080, (iPlayableService.evVideoSizeChanged,)),
+			"Is480": (self.IS_480, (iPlayableService.evVideoSizeChanged,)),
+			"Is4K": (self.IS_4K, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"Is576": (self.IS_576, (iPlayableService.evVideoSizeChanged,)),
+			"Is720": (self.IS_720, (iPlayableService.evVideoSizeChanged,)),
+			"IsCrypted": (self.IS_CRYPTED, (iPlayableService.evUpdatedInfo,)),
+			"IsHD": (self.IS_HD, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"IsHDHDR": (self.IS_HDHDR, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"IsHDR": (self.IS_HDR, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"IsHDR10": (self.IS_HDR10, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"IsHLG": (self.IS_HLG, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"IsIPStream": (self.IS_STREAM, (iPlayableService.evUpdatedInfo,)),
+			"IsMultichannel": (self.IS_MULTICHANNEL, (iPlayableService.evUpdatedInfo,)),
+			"IsNotWidescreen": (self.IS_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged,)),
+			"IsSD": (self.IS_SD, (iPlayableService.evVideoSizeChanged,)),
+			# "IsSDAndNotWidescreen": (self.IS_SD_AND_NOT_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
+			# "IsSDAndWidescreen": (self.IS_SD_AND_WIDESCREEN, (iPlayableService.evVideoSizeChanged, iPlayableService.evUpdatedInfo)),
+			"IsSDR": (self.IS_SDR, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoGammaChanged)),
+			"IsStereo": (self.IS_STEREO, (iPlayableService.evUpdatedInfo,)),
+			"IsStream": (self.IS_STREAM, (iPlayableService.evUpdatedInfo,)),
+			# "IsVideoAVC": (self.IS_VIDEO_AVC, (iPlayableService.evUpdatedInfo,)),
+			# "IsVideoHEVC": (self.IS_VIDEO_HEVC, (iPlayableService.evUpdatedInfo,)),
+			# "IsVideoMPEG2": (self.IS_VIDEO_MPEG2, (iPlayableService.evUpdatedInfo,)),
+			"IsWidescreen": (self.IS_WIDESCREEN, (iPlayableService.evVideoSizeChanged,)),
+			"OnId": (self.ONID, (iPlayableService.evUpdatedInfo,)),
+			"PcrPid": (self.PCRPID, (iPlayableService.evUpdatedInfo,)),
+			"PmtPid": (self.PMTPID, (iPlayableService.evUpdatedInfo,)),
+			"Progressive": (self.PROGRESSIVE, (iPlayableService.evVideoProgressiveChanged, iPlayableService.evUpdatedInfo)),
+			# "Provider": (self.PROVIDER, self.getTextItem, (iPlayableService.evStart,)),
+			# "Reference": (self.REFERENCE, self.getTextItem, (iPlayableService.evStart,)),
+			"Sid": (self.SID, (iPlayableService.evUpdatedInfo,)),
+			"SubservicesAvailable": (self.SUBSERVICES_AVAILABLE, (iPlayableService.evUpdatedEventInfo,)),
+			"SubtitlesAvailable": (self.SUBTITLES_AVAILABLE, (iPlayableService.evUpdatedInfo,)),
+			"TransferBPS": (self.TRANSFERBPS, (iPlayableService.evUpdatedInfo,)),
+			"TsId": (self.TSID, (iPlayableService.evUpdatedInfo,)),
+			"TxtPid": (self.TXTPID, (iPlayableService.evUpdatedInfo,)),
+			"VideoHeight": (self.YRES, (iPlayableService.evVideoSizeChanged,)),
+			"VideoInfo": (self.VIDEO_INFORMATION, (iPlayableService.evVideoSizeChanged, iPlayableService.evVideoFramerateChanged, iPlayableService.evVideoProgressiveChanged, iPlayableService.evUpdatedInfo)),
+			"VideoPid": (self.VPID, (iPlayableService.evUpdatedInfo,)),
+			# "VideoSize": (self.VIDEO_SIZE, (iPlayableService.evVideoSizeChanged,)),
+			"VideoWidth": (self.XRES, (iPlayableService.evVideoSizeChanged,)),
+		}.get(argument)
+		self.instanceInfoBarSubserviceSelection = None
 
 	@cached
 	def getBoolean(self):
-		service = self.source.service
-		isRef = isinstance(service, eServiceReference)
-		info = service.info() if (service and not isRef) else None
-		if info:
-			if self.type == self.HAS_TELETEXT:
-				tpid = info.getInfo(iServiceInformation.sTXTPID)
-				return tpid != -1
-			elif self.type in (self.IS_MULTICHANNEL, self.IS_STEREO):
-				# FIXME. but currently iAudioTrackInfo doesn't provide more information.
-				audio = service.audioTracks()
-				if audio:
-					n = audio.getNumberOfTracks()
-					idx = 0
-					while idx < n:
-						i = audio.getTrackInfo(idx)
-						description = StdAudioDesc(i.getDescription())
-						if description and description.split()[0] in ("AC4", "AAC+", "AC3", "AC3+", "Dolby", "DTS", "DTS-HD", "HE-AAC", "WMA"):
-							if self.type == self.IS_MULTICHANNEL:
-								return True
-							elif self.type == self.IS_STEREO:
-								return False
-						idx += 1
-					if self.type == self.IS_MULTICHANNEL:
-						return False
-					elif self.type == self.IS_STEREO:
-						return True
-				return False
-			elif self.type == self.IS_CRYPTED:
-				return info.getInfo(iServiceInformation.sIsCrypted) == 1
-			elif self.type == self.SUBSERVICES_AVAILABLE:
-				return hasActiveSubservicesForCurrentChannel(service)
-			elif self.type == self.HAS_HBBTV:
-				return info.getInfoString(iServiceInformation.sHBBTVUrl) != ""
-			elif self.type == self.AUDIOTRACKS_AVAILABLE:
-				audio = service.audioTracks()
-				return bool(audio and audio.getNumberOfTracks() > 1)
-			elif self.type == self.SUBTITLES_AVAILABLE:
-				subtitle = service and service.subtitle()
-				return bool(subtitle and subtitle.getSubtitleList())
-			elif self.type == self.EDITMODE:
-				return bool(hasattr(self.source, "editmode") and self.source.editmode)
-			elif self.type == self.IS_STREAM:
-				return service.streamed() is not None
-			elif self.isVideoService(info):
-				if self.type == self.IS_SDR:
-					return info.getInfo(iServiceInformation.sGamma) == 0
-				elif self.type == self.IS_HDR:
-					return info.getInfo(iServiceInformation.sGamma) == 1
-				elif self.type == self.IS_HDR10:
-					return info.getInfo(iServiceInformation.sGamma) == 2
-				elif self.type == self.IS_HLG:
-					return info.getInfo(iServiceInformation.sGamma) == 3
-				elif self.type == self.IS_HDHDR:
-					return info.getInfo(iServiceInformation.sGamma) > 0
-				elif self.type == self.IS_WIDESCREEN:
-					return info.getInfo(iServiceInformation.sAspect) in WIDESCREEN
-				elif self.type == self.IS_NOT_WIDESCREEN:
-					return info.getInfo(iServiceInformation.sAspect) not in WIDESCREEN
-				elif self.type == self.IS_VIDEO_MPEG2:
-					return info.getInfo(iServiceInformation.sVideoType) == 0
-				elif self.type == self.IS_VIDEO_AVC:
-					return info.getInfo(iServiceInformation.sVideoType) == 1
-				elif self.type == self.IS_VIDEO_HEVC:
-					return info.getInfo(iServiceInformation.sVideoType) == 7
+		def isMultichannelAudio(invert):
+			audio = service.audioTracks()
+			if audio and audio.getNumberOfTracks():
+				currentTrack = audio.getCurrentTrack()
+				if currentTrack > -1:
+					description = audio.getTrackInfo(currentTrack).getDescription()  # Some audio descriptions have 'audio' as additional value (e.g. "AC-3 audio").
+					result = bool(description and description.split()[0] in ("AC3", "AC3+", "DTS", "DTS-HD", "AC4", "LPCM", "Dolby", "HE-AAC", "AAC+", "WMA"))
+					if invert:
+						result = not result
 				else:
-					videoHeight = info.getInfo(iServiceInformation.sVideoHeight)
-					self.videoHeight = videoHeight if videoHeight > 0 else self.videoHeight
-					if self.type == self.IS_SD:
-						return self.videoHeight and self.videoHeight < 720
-					elif self.type == self.IS_HD:
-						return self.videoHeight >= 720 and self.videoHeight < 1500
-					elif self.type == self.IS_4K:
-						return self.videoHeight >= 1500
-					elif self.type == self.IS_1080:
-						return self.videoHeight > 1000 and self.videoHeight <= 1080
-					elif self.type == self.IS_720:
-						return self.videoHeight == 720
-					else:
-						aspect = info.getInfo(iServiceInformation.sAspect)
-						self.aspect = aspect if aspect > -1 else self.aspect
-						if self.type == self.IS_SD_AND_WIDESCREEN:
-							return self.videoHeight and self.aspect and self.videoHeight < 720 and self.aspect in WIDESCREEN
-						if self.type == self.IS_SD_AND_NOT_WIDESCREEN:
-							return self.videoHeight and self.aspect and self.videoHeight < 720 and self.aspect not in WIDESCREEN
-		return False
+					result = False
+			else:
+				result = False
+			return result
+
+		result = False
+		service = self.source.service
+		info = service and service.info()
+		if info:
+			videoData = info.getInfoString(iServiceInformation.sVideoInfo) or "-1|-1|-1|-1|-1|-1"
+			videoData = [int(x) for x in videoData.split("|")]
+			videoWidth = videoData[self.VIDEO_INFO_WIDTH] if videoData[self.VIDEO_INFO_WIDTH] != -1 else eAVControl.getInstance().getResolutionX(0)
+			videoHeight = videoData[self.VIDEO_INFO_HEIGHT] if videoData[self.VIDEO_INFO_HEIGHT] != -1 else eAVControl.getInstance().getResolutionY(0)
+			videoAspect = videoData[self.VIDEO_INFO_ASPECT] if videoData[self.VIDEO_INFO_ASPECT] != -1 else eAVControl.getInstance().getAspect(0)
+			videoGamma = videoData[self.VIDEO_INFO_GAMMA]
+			match self.token:
+				case self.AUDIOTRACKS_AVAILABLE:
+					audio = service.audioTracks()
+					result = audio and audio.getNumberOfTracks() > 1
+				case self.EDITMODE:
+					result = bool(hasattr(self.source, "editmode") and self.source.editmode)
+				case self.HAS_HBBTV:
+					result = info.getInfoString(iServiceInformation.sHBBTVUrl) != ""
+				case self.HAS_TELETEXT:
+					result = info.getInfo(iServiceInformation.sTXTPID) != -1
+				case self.IS_1080:
+					result = videoHeight > 1000 and videoHeight <= 1080
+				case self.IS_480:
+					result = videoHeight > 0 and videoHeight <= 480
+				case self.IS_4K:
+					result = videoHeight > 1500 and videoWidth <= 3840
+				case self.IS_576:
+					result = videoHeight > 500 and videoHeight <= 576
+				case self.IS_720:
+					result = videoHeight > 700 and videoHeight <= 720
+				case self.IS_CRYPTED:
+					result = info.getInfo(iServiceInformation.sIsCrypted) == 1
+				case self.IS_HD:
+					result = videoHeight > 700 and videoHeight <= 1080
+				case self.IS_HDHDR:
+					result = videoWidth > 720 and videoWidth < 1980 and videoGamma > 0
+				case self.IS_HDR:
+					result = videoWidth > 2160 and videoWidth <= 3840 and videoGamma == 1
+				case self.IS_HDR10:
+					result = videoWidth > 2160 and videoWidth <= 3840 and videoGamma == 2
+				case self.IS_HLG:
+					result = videoWidth > 2160 and videoWidth <= 3840 and videoGamma == 3
+				case self.IS_MULTICHANNEL:
+					result = isMultichannelAudio(False)
+				case self.IS_NOT_WIDESCREEN:
+					result = videoAspect not in WIDESCREEN
+				case self.IS_SD:
+					result = videoHeight < 720
+				case self.IS_SDR:
+					result = videoWidth > 2160 and videoWidth <= 3840 and videoGamma == 0
+				case self.IS_SD_AND_NOT_WIDESCREEN:
+					result = videoHeight < 720 and videoAspect not in WIDESCREEN
+				case self.IS_SD_AND_WIDESCREEN:
+					result = videoHeight < 720 and videoAspect in WIDESCREEN
+				case self.IS_STEREO:
+					result = isMultichannelAudio(True)
+				case self.IS_STREAM:
+					result = service.streamed() is not None
+				case self.IS_VIDEO_AVC:
+					result = info.getInfo(iServiceInformation.sVideoType) == 1
+				case self.IS_VIDEO_HEVC:
+					result = info.getInfo(iServiceInformation.sVideoType) == 7
+				case self.IS_VIDEO_MPEG2:
+					result = info.getInfo(iServiceInformation.sVideoType) == 0
+				case self.IS_WIDESCREEN:
+					result = videoAspect in WIDESCREEN
+				case self.PROGRESSIVE:
+					result = videoData[self.VIDEO_INFO_PROGRESSIVE] if videoData[self.VIDEO_INFO_PROGRESSIVE] != -1 else eAVControl.getInstance().getProgressive()
+				case self.SUBSERVICES_AVAILABLE:
+					if self.instanceInfoBarSubserviceSelection is None:
+						from Screens.InfoBarGenerics import instanceInfoBarSubserviceSelection  # This must be here as the class won't be initialized at module load time.
+						self.instanceInfoBarSubserviceSelection = instanceInfoBarSubserviceSelection
+					if self.instanceInfoBarSubserviceSelection:
+						result = self.instanceInfoBarSubserviceSelection.hasActiveSubservicesForCurrentService(info.getInfoString(iServiceInformation.sServiceref))
+				case self.SUBTITLES_AVAILABLE:
+					subtitle = service and service.subtitle()
+					result = bool(subtitle and subtitle.getSubtitleList())
+		# print(f"[ServiceInfo] DEBUG: Converter Boolean argument '{self.argument}' result is '{result}'{"." if isinstance(result, bool) else " TYPE MISMATCH!"}")
+		return result
 
 	boolean = property(getBoolean)
 
 	@cached
 	def getText(self):
+		result = ""
 		service = self.source.service
 		info = service and service.info()
 		if info:
-			if self.type == self.APID:
-				return self.getServiceInfoString(info, iServiceInformation.sAudioPID)
-			elif self.type == self.PCRPID:
-				return self.getServiceInfoString(info, iServiceInformation.sPCRPID)
-			elif self.type == self.PMTPID:
-				return self.getServiceInfoString(info, iServiceInformation.sPMTPID)
-			elif self.type == self.TXTPID:
-				return self.getServiceInfoString(info, iServiceInformation.sTXTPID)
-			elif self.type == self.TSID:
-				return self.getServiceInfoString(info, iServiceInformation.sTSID)
-			elif self.type == self.ONID:
-				return self.getServiceInfoString(info, iServiceInformation.sONID)
-			elif self.type == self.SID:
-				return self.getServiceInfoString(info, iServiceInformation.sSID)
-			elif self.type == self.TRANSFERBPS:
-				return self.getServiceInfoString(info, iServiceInformation.sTransferBPS, lambda x: _("%d kB/s") % (x / 1024))
-			elif self.type == self.HAS_HBBTV:
-				return info.getInfoString(iServiceInformation.sHBBTVUrl)
-			elif self.isVideoService(info):
-				if self.type == self.XRES:
-					return self.getServiceInfoString(info, iServiceInformation.sVideoWidth)
-				elif self.type == self.YRES:
-					return self.getServiceInfoString(info, iServiceInformation.sVideoHeight)
-				elif self.type == self.FRAMERATE:
-					return self.getServiceInfoString(info, iServiceInformation.sFrameRate, lambda x: _("%d fps") % ((x + 500) // 1000))
-				elif self.type == self.VPID:
-					return self.getServiceInfoString(info, iServiceInformation.sVideoPID)
-		return ""
+			videoData = info.getInfoString(iServiceInformation.sVideoInfo) or "-1|-1|-1|-1|-1|-1"
+			videoData = [int(x) for x in videoData.split("|")]
+			videoWidth = videoData[self.VIDEO_INFO_WIDTH] if videoData[self.VIDEO_INFO_WIDTH] != -1 else eAVControl.getInstance().getResolutionX(0)
+			videoHeight = videoData[self.VIDEO_INFO_HEIGHT] if videoData[self.VIDEO_INFO_HEIGHT] != -1 else eAVControl.getInstance().getResolutionY(0)
+			frameRate = videoData[self.VIDEO_INFO_FRAME_RATE] if videoData[self.VIDEO_INFO_FRAME_RATE] != -1 else eAVControl.getInstance().getFrameRate(0)
+			progressive = videoData[self.VIDEO_INFO_PROGRESSIVE] if videoData[self.VIDEO_INFO_PROGRESSIVE] != -1 else eAVControl.getInstance().getProgressive()
+			progressive = "p" if progressive else "i"
+			match self.token:
+				case self.APID:
+					result = info.getInfoString(iServiceInformation.sAudioPID)
+				case self.FRAMERATE:
+					result = f"{(frameRate + 500) // 1000} fps" if frameRate else _("N/A")
+				case self.FREQUENCY_INFORMATION:
+					feInfo = service.frontendInfo()
+					if feInfo:
+						feRaw = feInfo.getAll(False)
+						if feRaw:
+							feData = ConvertToHumanReadable(feRaw)
+							if feData:
+								srText = "Sr:"
+								symbolRate = int(feData.get("symbol_rate", 0))
+								if symbolRate == 0:
+									srText = ""
+									symbolRate = ""
+								result = f"Freq: {feData.get("frequency")} {feData.get("polarization_abbreviation") or ""} {srText} {symbolRate} {feData.get("fec_inner") or ""}"
+				case self.HAS_HBBTV:
+					result = info.getInfoString(iServiceInformation.sHBBTVUrl)
+				case self.ONID:
+					result = info.getInfoString(iServiceInformation.sONID)
+				case self.PCRPID:
+					result = info.getInfoString(iServiceInformation.sPCRPID)
+				case self.PMTPID:
+					result = info.getInfoString(iServiceInformation.sPMTPID)
+				case self.PROGRESSIVE:
+					result = progressive
+				case self.SID:
+					result = f"{info.getInfo(iServiceInformation.sSID):04X}"
+				case self.TRANSFERBPS:
+					result = info.getInfoString(iServiceInformation.sTransferBPS, lambda x: f"{x // 1024} kB/s")
+				case self.TSID:
+					result = info.getInfoString(iServiceInformation.sTSID)
+				case self.TXTPID:
+					result = info.getInfoString(iServiceInformation.sTXTPID)
+				case self.VIDEO_INFORMATION:
+					if frameRate > 0:
+						if progressive == "i":
+							frameRate *= 2
+						frameRate = f" {(frameRate + 500) // 1000}Hz"
+					else:
+						frameRate = ""
+					result = f"{videoWidth}x{videoHeight}{progressive}{frameRate}" if videoWidth != -1 and videoHeight != -1 else ""
+				case self.VPID:
+					result = info.getInfoString(iServiceInformation.sVideoPID)
+				case self.XRES:
+					result = f"{videoWidth}"
+				case self.YRES:
+					result = f"{videoHeight}"
+		# print(f"[ServiceInfo] DEBUG: Converter string argument '{self.argument}' result is '{result}'{"." if isinstance(result, str) else " TYPE MISMATCH!"}")
+		return result
 
 	text = property(getText)
 
 	@cached
 	def getValue(self):
+		result = -1
 		service = self.source.service
 		info = service and service.info()
-		if info and self.isVideoService(info):
-			if self.type == self.XRES:
-				return info.getInfo(iServiceInformation.sVideoWidth)
-			if self.type == self.YRES:
-				return info.getInfo(iServiceInformation.sVideoHeight)
-			if self.type == self.FRAMERATE:
-				return info.getInfo(iServiceInformation.sFrameRate)
-		return -1
+		if info:
+			match self.token:
+				case self.FRAMERATE:
+					result = info.getInfo(iServiceInformation.sFrameRate)
+					if result == -1:
+						result = eAVControl.getInstance().getFrameRate(0)
+				case self.XRES:
+					result = info.getInfo(iServiceInformation.sVideoWidth)
+					if result == -1:
+						result = eAVControl.getInstance().getResolutionX(0)
+				case self.YRES:
+					result = info.getInfo(iServiceInformation.sVideoHeight)
+					if result == -1:
+						result = eAVControl.getInstance().getResolutionY(0)
+		# print(f"[ServiceInfo] DEBUG: Converter value argument '{self.argument}' result is '{result}'{"." if isinstance(result, int) else " TYPE MISMATCH!"}")
+		return result
 
 	value = property(getValue)
 
 	def changed(self, what):
-		if what[0] != self.CHANGED_SPECIFIC or what[1] in self.interesting_events:
+		if what[0] != self.CHANGED_SPECIFIC or what[1] in self.interestingEvents:
 			Converter.changed(self, what)

--- a/lib/python/Components/UsageConfig.py
+++ b/lib/python/Components/UsageConfig.py
@@ -238,6 +238,7 @@ def InitUsageConfig():
 	config.usage.show_infobar_on_skip = ConfigYesNo(default=True)
 	config.usage.show_infobar_on_event_change = ConfigYesNo(default=False)
 	config.usage.show_second_infobar = ConfigSelection(default="0", choices=[("no", _("None"))] + choicelist + [("EPG", _("EPG"))])
+	config.usage.showInfoBarSubservices = ConfigSelection(default=1, choices=[(0, _("Off")),(1, _("If EPG available")),(2, _("Always"))])
 	config.usage.show_simple_second_infobar = ConfigYesNo(default=False)
 	config.usage.show_infobar_adds = ConfigYesNo(default=False)
 	config.usage.infobar_frontend_source = ConfigSelection(default="settings", choices=[("settings", _("Settings")), ("tuner", _("Tuner"))])

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -12,6 +12,7 @@ from Components.ServiceList import ServiceList, ServiceListLegacy, refreshServic
 from Components.ActionMap import NumberActionMap, ActionMap, HelpableActionMap, HelpableNumberActionMap
 from Components.MenuList import MenuList
 from Components.ServiceEventTracker import ServiceEventTracker, InfoBarBase
+from ServiceReference import ServiceReference, getStreamRelayRef, serviceRefAppendPath, service_types_radio_ref, service_types_tv_ref
 from enigma import eServiceReference, eServiceReferenceDVB, eEPGCache, eServiceCenter, eRCInput, eTimer, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode, loadPNG, eProfileWrite
 eProfileWrite("ChannelSelection.py 1")
 from Screens.EpgSelection import EPGSelection
@@ -38,12 +39,10 @@ from Screens.Hotkey import InfoBarHotkey, hotkeyActionMap, hotkey
 eProfileWrite("ChannelSelection.py 4")
 from Screens.PictureInPicture import PictureInPicture
 from Screens.RdsDisplay import RassInteractive
-from ServiceReference import ServiceReference, getStreamRelayRef
 from Tools.BoundFunction import boundFunction
 from Tools.Notifications import RemovePopup
 from Tools.Alternatives import GetWithAlternative, CompareWithAlternatives
 from Tools.Directories import fileExists, resolveFilename, sanitizeFilename, SCOPE_PLUGINS
-from Tools.ServiceReference import service_types_tv_ref, service_types_radio_ref, serviceRefAppendPath
 from Plugins.Plugin import PluginDescriptor
 from Components.PluginComponent import plugins
 from Screens.ChoiceBox import ChoiceBox
@@ -198,9 +197,10 @@ class ChannelContextMenu(Screen):
 				"1": self.unhideParentalServices,
 				"2": self.renameEntry,
 				"3": self.findCurrentlyPlayed,
-				"4": self.insertEntry,
-				"5": self.addServiceToBouquetOrAlternative,
-				"6": self.toggleMoveModeSelect,
+				"4": self.showSubservices,
+				"5": self.insertEntry,
+				"6": self.addServiceToBouquetOrAlternative,
+				"7": self.toggleMoveModeSelect,
 				"8": self.removeEntry
 			})
 		menu = []
@@ -216,11 +216,14 @@ class ChannelContextMenu(Screen):
 		inAlternativeList = current_root and 'FROM BOUQUET "alternatives' in current_root.getPath()
 		self.inBouquet = csel.getMutableList() is not None
 		haveBouquets = config.usage.multibouquet.value
+		self.subservices = csel.getSubservices(current)
 		from Components.ParentalControl import parentalControl
 		self.parentalControl = parentalControl
 		self.parentalControlEnabled = config.ParentalControl.servicepin[0].value and config.ParentalControl.servicepinactive.value
 		if not (current_sel_path or current_sel_flags & (eServiceReference.isDirectory | eServiceReference.isMarker)) or current_sel_flags & eServiceReference.isGroup:
 			append_when_current_valid(current, menu, (_("Show transponder info"), self.showServiceInformations), level=2)
+		if self.subservices and not csel.isSubservices():
+			appendWhenValid(current, menu, (_("Show Subservices Of Active Service"), self.showSubservices), key="4")
 		if csel.bouquet_mark_edit == OFF and not csel.entry_marked:
 			if not self.inBouquetRootList:
 				isPlayable = not (current_sel_flags & (eServiceReference.isMarker | eServiceReference.isDirectory))
@@ -266,22 +269,23 @@ class ChannelContextMenu(Screen):
 							appendWhenValid(current, menu, (_("Translate Subs On This Service"), self.removeNoAITranslationFlag))
 						else:
 							appendWhenValid(current, menu, (_("Don't Translate Subs On This Service"), self.addNoAITranslationFlag))
-					if haveBouquets:
-						bouquets = self.csel.getBouquetList()
-						if bouquets is None:
-							bouquetCnt = 0
+					if not csel.isSubservices():
+						if haveBouquets:
+							bouquets = self.csel.getBouquetList()
+							if bouquets is None:
+								bouquetCnt = 0
+							else:
+								bouquetCnt = len(bouquets)
+							if not self.inBouquet or bouquetCnt > 1:
+								append_when_current_valid(current, menu, (_("Add service to bouquet"), self.addServiceToBouquetSelected), level=0, key="5")
+								self.addFunction = self.addServiceToBouquetSelected
+							if not self.inBouquet:
+								append_when_current_valid(current, menu, (_("Remove entry"), self.removeEntry), level=0, key="8")
+								self.removeFunction = self.removeSatelliteService
 						else:
-							bouquetCnt = len(bouquets)
-						if not self.inBouquet or bouquetCnt > 1:
-							append_when_current_valid(current, menu, (_("Add service to bouquet"), self.addServiceToBouquetSelected), level=0, key="5")
-							self.addFunction = self.addServiceToBouquetSelected
-						if not self.inBouquet:
-							append_when_current_valid(current, menu, (_("Remove entry"), self.removeEntry), level=0, key="8")
-							self.removeFunction = self.removeSatelliteService
-					else:
-						if not self.inBouquet:
-							append_when_current_valid(current, menu, (_("Add service to favourites"), self.addServiceToBouquetSelected), level=0, key="5")
-							self.addFunction = self.addServiceToBouquetSelected
+							if not self.inBouquet:
+								append_when_current_valid(current, menu, (_("Add service to favourites"), self.addServiceToBouquetSelected), level=0, key="5")
+								self.addFunction = self.addServiceToBouquetSelected
 					if BoxInfo.getItem("PIPAvailable"):
 						self.PiPAvailable = True
 						if self.csel.dopipzap:
@@ -561,6 +565,10 @@ class ChannelContextMenu(Screen):
 			else:
 				current = eServiceReference(GetWithAlternative(current.toString()))
 		self.session.openWithCallback(self.close, ServiceInfo, current)
+
+	def showSubservices(self):
+		self.csel.enterSubservices(self.csel.getCurrentSelection(), self.subservices)
+		self.close()
 
 	def setStartupService(self):
 		self.session.openWithCallback(self.setStartupServiceCallback, MessageBox, _("Set startup service"), list=[(_("Only on startup"), "startup"), (_("Also on standby"), "standby")])
@@ -1363,6 +1371,16 @@ class ChannelSelectionEdit:
 		else:
 			self.servicelist.addMarked(ref)
 
+	def buildBouquetID(self, str):
+		tmp = str.lower()
+		name = ""
+		for c in tmp:
+			if ("a" <= c <= "z") or ("0" <= c <= "9"):
+				name += c
+			else:
+				name += "_"
+		return name
+
 	def removeCurrentEntry(self, bouquet=False):
 		if self.confirmRemove:
 			list = [(_("yes"), True), (_("no"), False), (_("yes") + " " + _("and never ask in this session again"), "never")]
@@ -1475,18 +1493,21 @@ class ChannelSelectionEdit:
 MODE_TV = 0
 MODE_RADIO = 1
 
+subservices_tv_ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory)
+subservices_tv_ref.setPath("FROM BOUQUET \"groupedservices.virtualsubservices.tv\"")
+
 service_types_tv = service_types_tv_ref.toString()
 service_types_radio = service_types_radio_ref.toString()
 
 multibouquet_tv_ref = eServiceReference(service_types_tv_ref)
-multibouquet_tv_ref.setPath('FROM BOUQUET "bouquets.tv" ORDER BY bouquet')
+multibouquet_tv_ref.setPath("FROM BOUQUET \"bouquets.tv\" ORDER BY bouquet")
 
-singlebouquet_tv_ref = serviceRefAppendPath(service_types_tv_ref, ' FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet')
+singlebouquet_tv_ref = serviceRefAppendPath(service_types_tv_ref, " FROM BOUQUET \"userbouquet.favourites.tv\" ORDER BY bouquet")
 
 multibouquet_radio_ref = eServiceReference(service_types_radio_ref)
-multibouquet_radio_ref.setPath('FROM BOUQUET "bouquets.radio" ORDER BY bouquet')
+multibouquet_radio_ref.setPath("FROM BOUQUET \"bouquets.radio\" ORDER BY bouquet")
 
-singlebouquet_radio_ref = serviceRefAppendPath(service_types_radio_ref, ' FROM BOUQUET "userbouquet.favourites.radio" ORDER BY bouquet')
+singlebouquet_radio_ref = serviceRefAppendPath(service_types_radio_ref, " FROM BOUQUET \"userbouquet.favourites.radio\" ORDER BY bouquet")
 
 
 class ChannelSelectionBase(Screen):
@@ -1578,6 +1599,7 @@ class ChannelSelectionBase(Screen):
 		self.servicetitle = ""
 		self.functiontitle = ""
 		self.recallBouquetMode()
+		self.instanceInfoBarSubserviceSelection = None
 
 	def compileTitle(self):
 		self.setTitle("%s%s%s%s" % (self.maintitle, self.modetitle, self.functiontitle, self.servicetitle))
@@ -1660,6 +1682,8 @@ class ChannelSelectionBase(Screen):
 				return _("Satellites")
 			if ') ORDER BY name' in pathstr:
 				return _("All")
+			if self.isSubservices(serviceReference):
+				return _("Subservices")
 		return str if config.usage.multibouquet.value else _("Favorites")
 
 	def buildTitleString(self):
@@ -1829,6 +1853,10 @@ class ChannelSelectionBase(Screen):
 							ref.setPath(path)
 							ref.setName(_("Current transponder"))
 							self.servicelist.addService(ref, beforeCurrent=True)
+							if self.getSubservices():  # Add subservices selection if available.
+								ref = eServiceReference(subservices_tv_ref)
+								ref.setName(self.getServiceName(ref))
+								self.servicelist.addService(ref, beforeCurrent=True)
 						for (service_name, service_ref) in addCableAndTerrestrialLater:
 							ref = eServiceReference(service_ref)
 							ref.setName(service_name)
@@ -2050,6 +2078,8 @@ class ChannelSelectionBase(Screen):
 
 	def getBouquetList(self):
 		bouquets = []
+		if self.isSubservices():
+			bouquets.append((self.getServiceName(subservices_tv_ref), subservices_tv_ref))
 		serviceHandler = eServiceCenter.getInstance()
 		if config.usage.multibouquet.value:
 			list = serviceHandler.list(self.bouquet_root)
@@ -2108,6 +2138,45 @@ class ChannelSelectionBase(Screen):
 			if playingref:
 				self.setCurrentSelectionAlternative(playingref)
 
+	def enterSubservices(self, service=None, subservices=[]):
+		subservices = subservices or self.getSubservices(service)
+		if subservices:
+			self.clearPath()
+			self.enterPath(subservices_tv_ref)
+			self.fillVirtualSubservices(service, subservices)
+
+	def getSubservices(self, service=None):
+		if not service:
+			service = self.session.nav.getCurrentlyPlayingServiceReference()
+		if self.instanceInfoBarSubserviceSelection is None:
+			from Screens.InfoBarGenerics import instanceInfoBarSubserviceSelection  # This must be here as the class won't be initialized at module load time.
+			self.instanceInfoBarSubserviceSelection = instanceInfoBarSubserviceSelection
+		if self.instanceInfoBarSubserviceSelection:
+			subserviceGroups = self.instanceInfoBarSubserviceSelection.getSubserviceGroups()
+			if subserviceGroups and service:
+				refstr = service.toCompareString()
+				if "%3a" in refstr:
+					refstr = service.toString()
+				ref_in_subservices_group = [x for x in subserviceGroups if refstr in x]
+				if ref_in_subservices_group:
+					return ref_in_subservices_group[0]
+		return []
+
+	def fillVirtualSubservices(self, service=None, subservices=[]):
+		self.servicelist.setMode(ServiceList.MODE_NORMAL)  # No numbers
+		for subservice in subservices or self.getSubservices(service):
+			self.servicelist.addService(eServiceReference(subservice))
+		# self.servicelist.sort()
+		self.setCurrentSelection(service or self.session.nav.getCurrentlyPlayingServiceReference())
+
+	def isSubservices(self, path=None):
+		return subservices_tv_ref == (path or self.getRoot())
+
+	def getMutableList(self, root=eServiceReference()):  # Override for subservices
+		# ChannelContextMenu.inBouquet = True --> Wrong menu
+		if self.isSubservices():
+			return None
+		return ChannelSelectionEdit.getMutableList(self, root)
 
 HISTORYSIZE = 20
 
@@ -2219,6 +2288,8 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 		self.restoreRoot()
 		lastservice = eServiceReference(self.lastservice.value)
 		if lastservice.valid():
+			if self.isSubservices():
+				self.enterSubservices(lastservice)
 			self.setCurrentSelection(lastservice)
 			ref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 			if ref and Components.ParentalControl.parentalControl.isProtected(ref):
@@ -2272,7 +2343,11 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 			self.setModeTv()
 		lastservice = eServiceReference(self.lastservice.value)
 		if lastservice.valid():
-			self.zap()
+			if self.isSubservices():
+				self.zap(ref=lastservice)
+				self.enterSubservices()
+			else:
+				self.zap()
 
 	def channelSelected(self, doClose=True):
 		ref = self.getCurrentSelection()
@@ -2286,7 +2361,9 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 		if self.movemode and (self.isBasePathEqual(self.bouquet_root) or "userbouquet." in ref.toString()):
 			self.toggleMoveMarked()
 		elif (ref.flags & eServiceReference.flagDirectory) == eServiceReference.flagDirectory:
-			if Components.ParentalControl.parentalControl.isServicePlayable(ref, self.bouquetParentalControlCallback, self.session):
+			if self.isSubservices(ref):
+				self.enterSubservices()
+			elif Components.ParentalControl.parentalControl.isServicePlayable(ref, self.bouquetParentalControlCallback, self.session):
 				self.enterPath(ref)
 				self.gotoCurrentServiceOrProvider(ref)
 				self.revertMode = None
@@ -2421,29 +2498,30 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 		return ret
 
 	def addToHistory(self, ref):
-		if self.delhistpoint is not None:
-			x = self.delhistpoint
-			while x <= len(self.history)-1:
-				del self.history[x]
-		self.delhistpoint = None
-
-		if self.servicePath is not None:
-			tmp = self.servicePath[:]
-			tmp.append(ref)
-			self.history.append(tmp)
-			hlen = len(self.history)
-			x = 0
-			while x < hlen - 1:
-				if self.history[x][-1] == ref:
+		if not self.isSubservices():
+			if self.delhistpoint is not None:
+				x = self.delhistpoint
+				while x <= len(self.history)-1:
 					del self.history[x]
-					hlen -= 1
-				else:
-					x += 1
+			self.delhistpoint = None
 
-			if hlen > HISTORYSIZE:
-				del self.history[0]
-				hlen -= 1
-			self.history_pos = hlen - 1
+			if self.servicePath is not None:
+				tmp = self.servicePath[:]
+				tmp.append(ref)
+				self.history.append(tmp)
+				hlen = len(self.history)
+				x = 0
+				while x < hlen - 1:
+					if self.history[x][-1] == ref:
+						del self.history[x]
+						hlen -= 1
+					else:
+						x += 1
+
+				if hlen > HISTORYSIZE:
+					del self.history[0]
+					hlen -= 1
+				self.history_pos = hlen - 1
 
 	def historyBack(self):
 		hlen = len(self.history)
@@ -2542,6 +2620,8 @@ class ChannelSelection(ChannelSelectionBase, ChannelSelectionEdit, ChannelSelect
 			if cnt:
 				path = self.servicePath.pop()
 				self.enterPath(path)
+				if self.isSubservices(path):
+					self.fillVirtualSubservices()
 			else:
 				self.showFavourites()
 				self.saveRoot()

--- a/lib/python/Screens/ChannelSelection.py
+++ b/lib/python/Screens/ChannelSelection.py
@@ -12,7 +12,7 @@ from Components.ServiceList import ServiceList, ServiceListLegacy, refreshServic
 from Components.ActionMap import NumberActionMap, ActionMap, HelpableActionMap, HelpableNumberActionMap
 from Components.MenuList import MenuList
 from Components.ServiceEventTracker import ServiceEventTracker, InfoBarBase
-from enigma import eServiceReference, eEPGCache, eServiceCenter, eRCInput, eTimer, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode, loadPNG, eProfileWrite
+from enigma import eServiceReference, eServiceReferenceDVB, eEPGCache, eServiceCenter, eRCInput, eTimer, eDVBDB, iPlayableService, iServiceInformation, getPrevAsciiCode, loadPNG, eProfileWrite
 eProfileWrite("ChannelSelection.py 1")
 from Screens.EpgSelection import EPGSelection
 from Components.config import config, configfile, ConfigSubsection, ConfigText, ConfigYesNo, ConfigSelection, ConfigText
@@ -43,6 +43,7 @@ from Tools.BoundFunction import boundFunction
 from Tools.Notifications import RemovePopup
 from Tools.Alternatives import GetWithAlternative, CompareWithAlternatives
 from Tools.Directories import fileExists, resolveFilename, sanitizeFilename, SCOPE_PLUGINS
+from Tools.ServiceReference import service_types_tv_ref, service_types_radio_ref, serviceRefAppendPath
 from Plugins.Plugin import PluginDescriptor
 from Components.PluginComponent import plugins
 from Screens.ChoiceBox import ChoiceBox
@@ -1109,8 +1110,8 @@ class ChannelSelectionEdit:
 		mutableList = self.getMutableList()
 		cnt = 0
 		while mutableList:
-			str = '1:64:%d:0:0:0:0:0:0:0::%s' % (cnt, name)
-			ref = eServiceReference(str)
+			ref = eServiceReference(eServiceReference.idDVB, eServiceReference.isMarker, cnt)
+			ref.setName(name)
 			if current and current.valid():
 				if not mutableList.addService(ref, current):
 					self.servicelist.addService(ref, True)
@@ -1130,12 +1131,14 @@ class ChannelSelectionEdit:
 		mutableBouquet = cur_root.list().startEdit()
 		if mutableBouquet:
 			name = cur_service.getServiceName()
-			refstr = '_'.join(cur_service.ref.toString().split(':'))
+			flags = eServiceReference.isGroup | eServiceReference.canDescent | eServiceReference.mustDescent
 			if self.mode == MODE_TV:
-				str = '1:134:1:0:0:0:0:0:0:0:FROM BOUQUET \"alternatives.%s.tv\" ORDER BY bouquet' % (refstr)
+				ref = eServiceReference(eServiceReference.idDVB, flags, eServiceReferenceDVB.dTv)
+				ref.setPath('FROM BOUQUET "alternatives.%s.tv" ORDER BY bouquet' % self.buildBouquetID(name))
 			else:
-				str = '1:134:2:0:0:0:0:0:0:0:FROM BOUQUET \"alternatives.%s.radio\" ORDER BY bouquet' % (refstr)
-			new_ref = ServiceReference(str)
+				ref = eServiceReference(eServiceReference.idDVB, flags, eServiceReferenceDVB.dRadio)
+				ref.setPath('FROM BOUQUET "alternatives.%s.radio" ORDER BY bouquet' % self.buildBouquetID(name))
+			new_ref = ServiceReference(ref)
 			if not mutableBouquet.addService(new_ref.ref, cur_service.ref):
 				mutableBouquet.removeService(cur_service.ref)
 				mutableBouquet.flushChanges()
@@ -1164,12 +1167,15 @@ class ChannelSelectionEdit:
 	def addBouquet(self, bName, services):
 		serviceHandler = eServiceCenter.getInstance()
 		mutableBouquetList = serviceHandler.list(self.bouquet_root).startEdit()
-		if mutableBouquetList:
-			name = sanitizeFilename(bName)
-			while os.path.isfile((self.mode == MODE_TV and '/etc/enigma2/userbouquet.%s.tv' or '/etc/enigma2/userbouquet.%s.radio') % name):
-				name = name.rsplit('_', 1)
-				name = ('_').join((name[0], len(name) == 2 and name[1].isdigit() and str(int(name[1]) + 1) or '1'))
-			new_bouquet_ref = eServiceReference((self.mode == MODE_TV and '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.%s.tv" ORDER BY bouquet' or '1:7:2:0:0:0:0:0:0:0:FROM BOUQUET "userbouquet.%s.radio" ORDER BY bouquet') % name)
+		if mutableBouquetList:			
+			if self.mode == MODE_TV:
+				bName = f"{bName} {_('(TV)')}"
+				new_bouquet_ref = eServiceReference(service_types_tv_ref)
+				new_bouquet_ref.setPath("FROM BOUQUET \"userbouquet.%s.tv\" ORDER BY bouquet" % self.buildBouquetID(bName))
+			else:
+				bName = f"{bName} {_('(Radio)')}"
+				new_bouquet_ref = eServiceReference(service_types_radio_ref)
+				new_bouquet_ref.setPath("FROM BOUQUET \"userbouquet.%s.radio\" ORDER BY bouquet" % self.buildBouquetID(bName))
 			if not mutableBouquetList.addService(new_bouquet_ref):
 				mutableBouquetList.flushChanges()
 				eDVBDB.getInstance().reloadBouquets()
@@ -1185,16 +1191,16 @@ class ChannelSelectionEdit:
 					print("get mutable list for new created bouquet failed")
 				# do some voodoo to check if current_root is equal to bouquet_root
 				cur_root = self.getRoot()
-				str1 = cur_root and cur_root.toString()
-				pos1 = str1 and str1.find("FROM BOUQUET") or -1
-				pos2 = self.bouquet_rootstr.find("FROM BOUQUET")
+				str1 = cur_root and cur_root.getPath()
+				pos1 = str1.find("FROM BOUQUET") if str1 else -1
+				pos2 = self.bouquet_root.getPath().find("FROM BOUQUET")
 				if pos1 != -1 and pos2 != -1 and str1[pos1:] == self.bouquet_rootstr[pos2:]:
 					self.servicelist.addService(new_bouquet_ref)
 					self.servicelist.resetRoot()
 			else:
-				print("add", str, "to bouquets failed")
+				print(f"[ChannelSelection] Add '{new_bouquet_ref.toString()}' to bouquets failed!")
 		else:
-			print("bouquetlist is not editable")
+			print("[ChannelSelection] The bouquet list is not editable.")
 
 	def copyCurrentToBouquetList(self):
 		provider = ServiceReference(self.getCurrentSelection())
@@ -1469,20 +1475,18 @@ class ChannelSelectionEdit:
 MODE_TV = 0
 MODE_RADIO = 1
 
-# type 1 = digital television service
-# type 4 = nvod reference service (NYI)
-# type 17 = MPEG-2 HD digital television service
-# type 22 = advanced codec SD digital television
-# type 24 = advanced codec SD NVOD reference service (NYI)
-# type 25 = advanced codec HD digital television
-# type 27 = advanced codec HD NVOD reference service (NYI)
-# type 31 = HEVC digital television service
-# type 32 = HEVC UHD digital television service with HDR and/or a frame rate of 100 Hz, 120 000/1 001 Hz, or 120 Hz, or any combination of HDR and these frame rates
-# type 2 = digital radio sound service
-# type 10 = advanced codec digital radio sound service
+service_types_tv = service_types_tv_ref.toString()
+service_types_radio = service_types_radio_ref.toString()
 
-service_types_tv = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 22) || (type == 25) || (type == 31) || (type == 32) || (type == 134) || (type == 195)'
-service_types_radio = '1:7:2:0:0:0:0:0:0:0:(type == 2) || (type == 10)'
+multibouquet_tv_ref = eServiceReference(service_types_tv_ref)
+multibouquet_tv_ref.setPath('FROM BOUQUET "bouquets.tv" ORDER BY bouquet')
+
+singlebouquet_tv_ref = serviceRefAppendPath(service_types_tv_ref, ' FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet')
+
+multibouquet_radio_ref = eServiceReference(service_types_radio_ref)
+multibouquet_radio_ref.setPath('FROM BOUQUET "bouquets.radio" ORDER BY bouquet')
+
+singlebouquet_radio_ref = serviceRefAppendPath(service_types_radio_ref, ' FROM BOUQUET "userbouquet.favourites.radio" ORDER BY bouquet')
 
 
 class ChannelSelectionBase(Screen):
@@ -1599,18 +1603,13 @@ class ChannelSelectionBase(Screen):
 
 	def recallBouquetMode(self):
 		if self.mode == MODE_TV:
-			self.service_types = service_types_tv
-			if config.usage.multibouquet.value:
-				self.bouquet_rootstr = '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "bouquets.tv" ORDER BY bouquet'
-			else:
-				self.bouquet_rootstr = '%s FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet' % (self.service_types)
+			self.service_types_ref = service_types_tv_ref
+			self.bouquet_root = eServiceReference(multibouquet_tv_ref if config.usage.multibouquet.value else singlebouquet_tv_ref)
 		else:
-			self.service_types = service_types_radio
-			if config.usage.multibouquet.value:
-				self.bouquet_rootstr = '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "bouquets.radio" ORDER BY bouquet'
-			else:
-				self.bouquet_rootstr = '%s FROM BOUQUET "userbouquet.favourites.radio" ORDER BY bouquet' % (self.service_types)
-		self.bouquet_root = eServiceReference(self.bouquet_rootstr)
+			self.service_types_ref = service_types_radio_ref
+			self.bouquet_root = eServiceReference(multibouquet_radio_ref if config.usage.multibouquet.value else singlebouquet_radio_ref)
+		self.service_types = self.service_types_ref.toString()
+		self.bouquet_rootstr = self.bouquet_root.toString()
 
 	def setTvMode(self):
 		self.mode = MODE_TV
@@ -1747,9 +1746,8 @@ class ChannelSelectionBase(Screen):
 
 	def showAllServices(self):
 		if not self.pathChangeDisabled:
-			refstr = '%s ORDER BY name' % (self.service_types)
-			if not self.preEnterPath(refstr):
-				ref = eServiceReference(refstr)
+			ref = serviceRefAppendPath(self.service_types_ref, 'FROM SATELLITES ORDER BY satellitePosition')
+			if not self.preEnterPath(ref.toString()):
 				currentRoot = self.getRoot()
 				if currentRoot is None or currentRoot != ref:
 					self.clearPath()
@@ -1761,8 +1759,7 @@ class ChannelSelectionBase(Screen):
 	def showSatellites(self, changeMode=False):
 		if not self.pathChangeDisabled:
 			refstr = '%s FROM SATELLITES ORDER BY satellitePosition' % (self.service_types)
-			if not self.preEnterPath(refstr):
-				ref = eServiceReference(refstr)
+			if not self.preEnterPath(ref.toString()):
 				justSet = False
 				prev = None
 
@@ -1822,13 +1819,14 @@ class ChannelSelectionBase(Screen):
 						cur_ref = self.session.nav.getCurrentlyPlayingServiceReference()
 						self.servicelist.sort()
 						if cur_ref:
-							pos = self.service_types.rfind(':')
-							refstr = '%s (channelID == %08x%04x%04x) && %s ORDER BY name' % (self.service_types[:pos + 1],
+							# pos = self.service_types.rfind(":")  # DEBUG NOTE: This doesn't appear to be used.
+							ref = eServiceReference(self.service_types_ref)
+							path = '(channelID == %08x%04x%04x) && %s ORDER BY name' % (
 								cur_ref.getUnsignedData(4), # NAMESPACE
 								cur_ref.getUnsignedData(2), # TSID
 								cur_ref.getUnsignedData(3), # ONID
-								self.service_types[pos + 1:])
-							ref = eServiceReference(refstr)
+								self.service_types_ref.getPath())
+							ref.setPath(path)
 							ref.setName(_("Current transponder"))
 							self.servicelist.addService(ref, beforeCurrent=True)
 						for (service_name, service_ref) in addCableAndTerrestrialLater:
@@ -1839,20 +1837,20 @@ class ChannelSelectionBase(Screen):
 						if prev is not None:
 							self.setCurrentSelection(prev)
 						elif cur_ref:
-							refstr = cur_ref.toString()
-							op = "".join(refstr.split(':', 10)[6:7])
-							if len(op) >= 4:
-								hop = int(op[:-4], 16)
-								if len(op) >= 7 and not op.endswith('0000'):
-									op = op[:-4] + '0000'
-								refstr = '1:7:0:0:0:0:%s:0:0:0:(satellitePosition == %s) && %s ORDER BY name' % (op, hop, self.service_types[self.service_types.rfind(':') + 1:])
-								self.setCurrentSelectionAlternative(eServiceReference(refstr))
+							op = cur_ref.getUnsignedData(4)
+							if op >= 0xffff:
+								hop = op >> 16
+								if op >= 0x10000000 and (op & 0xffff):
+									op &= 0xffff0000
+								path = f"(satellitePosition == {hop}) && {self.service_types_ref.getPath()} ORDER BY name"
+								ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory, path)
+								ref.setUnsignedData(4, op)
+								self.setCurrentSelectionAlternative(ref)
 
 	def showProviders(self):
 		if not self.pathChangeDisabled:
-			refstr = '%s FROM PROVIDERS ORDER BY name' % (self.service_types)
-			if not self.preEnterPath(refstr):
-				ref = eServiceReference(refstr)
+			ref = serviceRefAppendPath(self.service_types_ref, " FROM PROVIDERS ORDER BY name")
+			if not self.preEnterPath(ref.toString()):
 				if self.isBasePathEqual(ref):
 					self.pathUp()
 				else:
@@ -1865,14 +1863,16 @@ class ChannelSelectionBase(Screen):
 							info = service.info()
 							if info:
 								provider = info.getInfoString(iServiceInformation.sProvider)
-								refstr = '1:7:0:0:0:0:0:0:0:0:(provider == \"%s\") && %s ORDER BY name:%s' % (provider, self.service_types[self.service_types.rfind(':') + 1:], provider)
-								self.setCurrentSelectionAlternative(eServiceReference(refstr))
+								ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory)
+								ref.setPath("(provider == \"%s\") && %s ORDER BY name" % (provider, self.service_types_ref.getPath()))
+								ref.setName(provider)
+								self.setCurrentSelectionAlternative(ref)
 
 	def changeBouquet(self, direction):
 		if not self.pathChangeDisabled:
 			if len(self.servicePath) > 1:
 				#when enter satellite root list we must do some magic stuff..
-				ref = eServiceReference('%s FROM SATELLITES ORDER BY satellitePosition' % (self.service_types))
+				ref = serviceRefAppendPath(self.service_types_ref, " FROM SATELLITES ORDER BY satellitePosition")
 				if self.isBasePathEqual(ref):
 					self.showSatellites()
 				else:
@@ -1957,7 +1957,7 @@ class ChannelSelectionBase(Screen):
 
 	def showFavourites(self):
 		if not self.pathChangeDisabled:
-			if not self.preEnterPath(self.bouquet_rootstr):
+			if not self.preEnterPath(self.bouquet_root.toString()):
 				if self.isBasePathEqual(self.bouquet_root):
 					self.pathUp()
 				else:
@@ -2075,11 +2075,11 @@ class ChannelSelectionBase(Screen):
 			if self.isBasePathEqual(self.bouquet_root):
 				self.showFavourites()
 			else:
-				ref = eServiceReference('%s FROM SATELLITES ORDER BY satellitePosition' % (self.service_types))
+				ref = serviceRefAppendPath(self.service_types_ref, " FROM SATELLITES ORDER BY satellitePosition")
 				if self.isBasePathEqual(ref):
 					self.showSatellites()
 				else:
-					ref = eServiceReference('%s FROM PROVIDERS ORDER BY name' % (self.service_types))
+					ref = serviceRefAppendPath(self.service_types_ref, " FROM PROVIDERS ORDER BY name")
 					if self.isBasePathEqual(ref):
 						self.showProviders()
 					else:
@@ -2092,18 +2092,19 @@ class ChannelSelectionBase(Screen):
 		self.servicelist.moveToPrevMarker()
 
 	def gotoCurrentServiceOrProvider(self, ref):
-		str = ref.toString()
-		playingref = self.session.nav.getCurrentlyPlayingServiceReference()
-		if _("Providers") in str:
+		if _("Providers") in ref.getName():
 			service = self.session.nav.getCurrentService()
 			if service:
 				info = service.info()
-				if info and playingref:
+				if info:
 					provider = info.getInfoString(iServiceInformation.sProvider)
-					op = int(playingref.toString().split(':')[6][:-4] or "0", 16)
-					refstr = '1:7:0:0:0:0:0:0:0:0:(provider == \"%s\") && (satellitePosition == %s) && %s ORDER BY name:%s' % (provider, op, self.service_types[self.service_types.rfind(':') + 1:], provider)
-					self.setCurrentSelection(eServiceReference(refstr))
+					op = self.session.nav.getCurrentlyPlayingServiceOrGroup().getUnsignedData(4) >> 16
+					ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory)
+					ref.setPath("(provider == \"%s\") && (satellitePosition == %d) && %s ORDER BY name" % (provider, op, self.service_types_ref.getPath()))
+					ref.setName(provider)
+					self.servicelist.setCurrent(eServiceReference(ref))
 		elif not self.isBasePathEqual(self.bouquet_root) or self.bouquet_mark_edit == EDIT_ALTERNATIVES or (self.startRoot and self.startRoot != ref):
+			playingref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
 			if playingref:
 				self.setCurrentSelectionAlternative(playingref)
 

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -38,7 +38,7 @@ from Screens.UnhandledKey import UnhandledKey
 from ServiceReference import ServiceReference, getStreamRelayRef, isPlayableForCur
 
 from Tools.ASCIItranslit import legacyEncode
-from Tools.Directories import fileExists, fileReadLines, fileWriteLines, fileReadLinesISO, getRecordingFilename, moveFiles
+from Tools.Directories import SCOPE_CONFIG, SCOPE_SKINS, fileExists, fileReadLines, fileWriteLines, fileReadLinesISO, getRecordingFilename, moveFiles, resolveFilename
 from Tools.ServiceReference import hdmiInServiceRef
 from keyids import KEYFLAGS, KEYIDS, KEYIDNAMES
 from Tools.Notifications import AddPopup, AddNotificationWithCallback, current_notifications, lock, notificationAdded, notifications, RemovePopup
@@ -3157,12 +3157,20 @@ class InfoBarAudioSelection:
 			self.audioDownmixToggle(False)
 
 
+# Subservice processing.
+#
+instanceInfoBarSubserviceSelection = None
+
+
 class InfoBarSubserviceSelection:
 	def __init__(self):
+		global instanceInfoBarSubserviceSelection
+		instanceInfoBarSubserviceSelection = self
+		self.subservicesGroups = self.loadSubservicesGroups()
 		self["SubserviceSelectionAction"] = HelpableActionMap(self, ["InfobarSubserviceSelectionActions"],
 			{
 				"subserviceSelection": (self.subserviceSelection, _("Subservice list...")),
-			})
+			}, prio=0, description=_("Subservice Actions"))
 
 		self["SubserviceQuickzapAction"] = HelpableActionMap(self, ["InfobarSubserviceQuickzapActions"],
 			{
@@ -3180,6 +3188,60 @@ class InfoBarSubserviceSelection:
 
 	def __removeNotifications(self):
 		self.session.nav.event.remove(self.checkSubservicesAvail)
+
+	def loadSubservicesGroups(self):
+		subservicesGroups = []
+		groupedServicesFile = resolveFilename(SCOPE_CONFIG, "groupedservices")
+		if not isfile(groupedServicesFile):
+			groupedServicesFile = resolveFilename(SCOPE_SKINS, "groupedservices")
+			if not isfile(groupedServicesFile):
+				groupedServicesFile = None
+				print("[InfoBarGenerics] No 'groupedservices' file found so no subservices are available.")
+		if groupedServicesFile:
+			subservicesGroups = [list(g) for k, g in itertools.groupby([line.split("#")[0].strip() for line in fileReadLines(groupedServicesFile, [], source=MODULE_NAME)], lambda x: not x) if not k]
+			count = len(subservicesGroups)
+			print(f"[InfoBarGenerics] {count} subservice group{'' if count == 1 else 's'} loaded from '{groupedServicesFile}'.")
+		return subservicesGroups
+
+	def getSubserviceGroups(self):
+		return self.subservicesGroups
+
+	def hasActiveSubservicesForCurrentService(self, serviceReference):
+		if serviceReference and "%3a" not in serviceReference:
+			serviceReference = ":".join(serviceReference.split(":")[:11])
+		if config.usage.showInfoBarSubservices.value == 1:
+			subservices = self.getActiveSubservicesForCurrentService(serviceReference)
+		elif config.usage.showInfoBarSubservices.value == 2:
+			subservices = self.getPossibleSubservicesForCurrentService(serviceReference)
+		else:
+			subservices = None
+		return bool(subservices and len(subservices) > 1)
+
+	def getActiveSubservicesForCurrentService(self, serviceReference):
+		transmissionPaused = [
+			"Sendepause"  # This is for German TV.
+		]
+		activeSubservices = []
+		if config.usage.showInfoBarSubservices.value and serviceReference:
+			possibleSubservices = self.getPossibleSubservicesForCurrentService(serviceReference)
+			epgCache = eEPGCache.getInstance()
+			for subservice in possibleSubservices:
+				events = epgCache.lookupEvent(["T", (subservice, 0, -1)])
+				if events and len(events) == 1:
+					title = events[0][0]
+					if title and not any([x for x in transmissionPaused if x in title]):
+						activeSubservices.append(subservice)
+				elif config.usage.showInfoBarSubservices.value == 2:
+					activeSubservices.append(subservice)
+		return activeSubservices
+
+	def getPossibleSubservicesForCurrentService(self, serviceReference):
+		possibleSubservices = []
+		if serviceReference and self.subservicesGroups:
+			possibleSubserviceGroups = [x for x in self.subservicesGroups if serviceReference in x]
+			if possibleSubserviceGroups:
+				possibleSubservices = possibleSubserviceGroups[0]  # If the service is in multiple groups should we return more options?
+		return possibleSubservices
 
 	def checkSubservicesAvail(self):
 		serviceRef = self.session.nav.getCurrentlyPlayingServiceReference()

--- a/lib/python/Screens/InfoBarGenerics.py
+++ b/lib/python/Screens/InfoBarGenerics.py
@@ -39,6 +39,7 @@ from ServiceReference import ServiceReference, getStreamRelayRef, isPlayableForC
 
 from Tools.ASCIItranslit import legacyEncode
 from Tools.Directories import fileExists, fileReadLines, fileWriteLines, fileReadLinesISO, getRecordingFilename, moveFiles
+from Tools.ServiceReference import hdmiInServiceRef
 from keyids import KEYFLAGS, KEYIDS, KEYIDNAMES
 from Tools.Notifications import AddPopup, AddNotificationWithCallback, current_notifications, lock, notificationAdded, notifications, RemovePopup
 
@@ -4151,14 +4152,14 @@ class InfoBarHDMI:
 	def HDMIInLong(self):
 		if not hasattr(self.session, "pip") and not self.session.pipshown:
 			self.session.pip = self.session.instantiateDialog(PictureInPicture)
-			self.session.pip.playService(eServiceReference('8192:0:1:0:0:0:0:0:0:0:'))
+			self.session.pip.playService(hdmiInServiceRef())
 			self.session.pip.show()
 			self.session.pipshown = True
 			self.session.pip.servicePath = self.servicelist.getCurrentServicePath()
 		elif BoxInfo.getItem("HasHDMIinPiP"):
 			curref = self.session.pip.getCurrentService()
-			if curref and curref.type != 8192:
-				self.session.pip.playService(eServiceReference('8192:0:1:0:0:0:0:0:0:0:'))
+			if curref and curref.type != eServiceReference.idServiceHDMIIn:
+				self.session.pip.playService(hdmiInServiceRef())
 				self.session.pip.servicePath = self.servicelist.getCurrentServicePath()
 			else:
 				self.session.pipshown = False
@@ -4167,8 +4168,8 @@ class InfoBarHDMI:
 	def HDMIIn(self):
 		slist = self.servicelist
 		curref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
-		if curref and curref.type != 8192:
-			self.session.nav.playService(eServiceReference('8192:0:1:0:0:0:0:0:0:0:'))
+		if curref and curref.type != eServiceReference.idServiceHDMIIn:
+			self.session.nav.playService(hdmiInServiceRef())
 		else:
 			self.session.nav.playService(slist.servicelist.getCurrent())
 
@@ -4182,15 +4183,15 @@ class InfoBarHDMI:
 		if not hasattr(self.session, "pip") and not self.session.pipshown:
 			self.hdmi_enabled_pip = True
 			self.session.pip = self.session.instantiateDialog(PictureInPicture)
-			self.session.pip.playService(eServiceReference('8192:0:1:0:0:0:0:0:0:0:'))
+			self.session.pip.playService(hdmiInServiceRef())
 			self.session.pip.show()
 			self.session.pipshown = True
 			self.session.pip.servicePath = self.servicelist.getCurrentServicePath()
 		else:
 			curref = self.session.pip.getCurrentService()
-			if curref and curref.type != 8192:
+			if curref and curref.type != eServiceReference.idServiceHDMIIn:
 				self.hdmi_enabled_pip = True
-				self.session.pip.playService(eServiceReference('8192:0:1:0:0:0:0:0:0:0:'))
+				self.session.pip.playService(hdmiInServiceRef())
 				self.session.pip.servicePath = self.servicelist.getCurrentServicePath()
 			else:
 				self.hdmi_enabled_pip = False
@@ -4200,9 +4201,9 @@ class InfoBarHDMI:
 	def HDMIInFull(self):
 		slist = self.servicelist
 		curref = self.session.nav.getCurrentlyPlayingServiceOrGroup()
-		if curref and curref.type != 8192:
+		if curref and curref.type != eServiceReference.idServiceHDMIIn:
 			self.hdmi_enabled_full = True
-			self.session.nav.playService(eServiceReference('8192:0:1:0:0:0:0:0:0:0:'))
+			self.session.nav.playService(hdmiInServiceRef())
 		else:
 			self.hdmi_enabled_full = False
 			self.session.nav.playService(slist.servicelist.getCurrent())

--- a/lib/python/ServiceReference.py
+++ b/lib/python/ServiceReference.py
@@ -1,30 +1,44 @@
 # -*- coding: utf-8 -*-
-from enigma import eServiceReference, eServiceCenter, getBestPlayableServiceReference
+from enigma import eServiceReference, eServiceReferenceDVB, eServiceCenter, getBestPlayableServiceReference
 from Components.config import config
 import NavigationInstance
 
-# Global helper functions
 
+class ServiceReference(eServiceReference):
+	def __init__(self, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
+		if reftype != eServiceReference.idInvalid:
+			self.ref = eServiceReference(reftype, flags, path)
+		elif not isinstance(ref, eServiceReference):
+			self.ref = eServiceReference(ref or "")
+		else:
+			self.ref = ref
+		self.serviceHandler = eServiceCenter.getInstance()
 
-def getPlayingRef():
-	playingref = None
-	if NavigationInstance.instance:
-		playingref = NavigationInstance.instance.getCurrentlyPlayingServiceReference()
-	return playingref or eServiceReference()
+	def __str__(self):
+		return self.ref.toString()
 
+	def getServiceName(self):
+		info = self.info()
+		return info and info.getName(self.ref) or ""
 
-def isPlayableForCur(serviceref):
-	info = eServiceCenter.getInstance().info(serviceref)
-	return info and info.isPlayable(serviceref, getPlayingRef())
+	def info(self):
+		return self.serviceHandler.info(self.ref)
 
+	def list(self):
+		return self.serviceHandler.list(self.ref)
 
-def resolveAlternate(serviceref):
-	nref = None
-	if serviceref.flags & eServiceReference.isGroup:
-		nref = getBestPlayableServiceReference(serviceref, getPlayingRef())
-		if not nref:
-			nref = getBestPlayableServiceReference(serviceref, eServiceReference(), True)
-	return nref
+	def getType(self):
+		return self.ref.type
+
+	def getPath(self):
+		return self.ref.getPath()
+
+	def getFlags(self):
+		return self.ref.flags
+
+	def isRecordable(self):
+		ref = self.ref
+		return ref.flags & eServiceReference.isGroup or (ref.type == eServiceReference.idDVB or ref.type == eServiceReference.idDVB + 0x100 or ref.type == 0x2000 or ref.type == 0x1001)
 
 
 def getStreamRelayRef(sref):
@@ -39,71 +53,79 @@ def getStreamRelayRef(sref):
 		pass
 	return sref, False
 
-# Extensions to eServiceReference
 
-@staticmethod
-def __fromDirectory(path):
-	ref = eServiceReference(eServiceReference.idFile,
-			eServiceReference.flagDirectory |
-			eServiceReference.shouldSort | eServiceReference.sort1, path)
-	ref.setData(0, 1)
-	return ref
-
-
-eServiceReference.fromDirectory = __fromDirectory
-
-eServiceReference.isPlayback = lambda serviceref: "0:0:0:0:0:0:0:0:0" in serviceref.toCompareString()
-
-# Apply ServiceReference method proxies to the eServiceReference object so the two classes can be used interchangeably
-# These are required for ServiceReference backwards compatibility
-eServiceReference.isRecordable = lambda serviceref: serviceref.flags & eServiceReference.isGroup or (serviceref.type == eServiceReference.idDVB or serviceref.type == eServiceReference.idDVB + 0x100 or serviceref.type == 0x2000 or serviceref.type == 0x1001 or serviceref.type == eServiceReference.idServiceMP3)
+def getPlayingref(ref):
+	playingref = None
+	if NavigationInstance.instance:
+		playingref = NavigationInstance.instance.getCurrentlyPlayingServiceReference()
+		if playingref:
+			from Screens.InfoBarGenerics import streamrelay  # needs here to prevent cycle import
+			if streamrelay.checkService(playingref):
+				playingref.setAlternativeUrl(playingref.toString())
+	if not playingref:
+		playingref = eServiceReference()
+	return playingref
 
 
-def __repr(serviceref):
-	chnum = serviceref.getChannelNum()
-	chnum = ", ChannelNum=" + str(chnum) if chnum else ""
-	return "eServiceReference(Name=%s%s, String=%s)" % (serviceref.getServiceName(), chnum, serviceref.toString())
-eServiceReference.__repr__ = __repr
-def __toString(serviceref):
-	return serviceref.toString()
-eServiceReference.__str__ = __toString
-def __getServiceName(serviceref):
-	info = eServiceCenter.getInstance().info(serviceref)
-	return info and info.getName(serviceref) or ""
-eServiceReference.getServiceName = __getServiceName
-def __info(serviceref):
-	return eServiceCenter.getInstance().info(serviceref)
-eServiceReference.info = __info
-def __list(serviceref):
-	return eServiceCenter.getInstance().list(serviceref)
-eServiceReference.list = __list
-# ref is obsolete but kept for compatibility.
-# A ServiceReference *is* an eServiceReference now, so you no longer need to use .ref
-def __getRef(serviceref):
-	return serviceref
-def __setRef(self, serviceref):
-	eServiceReference.__init__(self, serviceref)
-eServiceReference.ref = property(__getRef, __setRef,)
-# getType is obsolete but kept for compatibility. Use "serviceref.type" instead
-def __getType(serviceref):
-	return serviceref.type
-eServiceReference.getType = __getType
-# getFlags is obsolete but kept for compatibility. Use "serviceref.flags" instead
-def __getFlags(serviceref):
-	return serviceref.flags
-eServiceReference.getFlags = __getFlags
-# Compatibility class that exposes eServiceReference as ServiceReference
-# Don't use this for new code. eServiceReference now supports everything in one single type
-class ServiceReference(eServiceReference):
-	def __new__(cls, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
-		# if trying to copy an eServiceReference object, turn it into a ServiceReference type and return it
-		if reftype == eServiceReference.idInvalid and isinstance(ref, eServiceReference):
-			new = ref
-			new.__class__ = ServiceReference
-			return new
-		return eServiceReference.__new__(cls)
-	def __init__(self, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
-		if reftype != eServiceReference.idInvalid:
-			eServiceReference.__init__(self, reftype, flags, path)
-		elif not isinstance(ref, eServiceReference):
-			eServiceReference.__init__(self, ref or "")
+def isPlayableForCur(ref):
+	info = eServiceCenter.getInstance().info(ref)
+	return info and info.isPlayable(ref, getPlayingref(ref))
+
+
+def resolveAlternate(ref):
+	nref = None
+	if ref.flags & eServiceReference.isGroup:
+		nref = getBestPlayableServiceReference(ref, getPlayingref(ref))
+		if not nref:
+			nref = getBestPlayableServiceReference(ref, eServiceReference(), True)
+	return nref
+
+
+def makeServiceQueryStr(serviceTypes):
+	return ' || '.join(['(type == %d)' % x for x in serviceTypes])
+
+
+# type 1 = digital television service
+# type 4 = nvod reference service (NYI)
+# type 17 = MPEG-2 HD digital television service
+# type 22 = advanced codec SD digital television
+# type 24 = advanced codec SD NVOD reference service (NYI)
+# type 25 = advanced codec HD digital television
+# type 27 = advanced codec HD NVOD reference service (NYI)
+# type 2 = digital radio sound service
+# type 10 = advanced codec digital radio sound service
+# type 31 = High Efficiency Video Coding digital television
+# type 32 = High Efficiency Video Coding digital television
+
+# Generate an eServiceRef query path containing
+# '(type == serviceTypes[0]) || (type == serviceTypes[1]) || ...'
+
+
+service_types_tv_ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory, eServiceReferenceDVB.dTv)
+
+service_types_tv_ref.setPath(makeServiceQueryStr((
+	eServiceReferenceDVB.dTv,
+	eServiceReferenceDVB.mpeg2HdTv,
+	eServiceReferenceDVB.avcSdTv,
+	eServiceReferenceDVB.avcHdTv,
+	eServiceReferenceDVB.nvecTv,
+	eServiceReferenceDVB.nvecTv20,
+	eServiceReferenceDVB.user134,
+	eServiceReferenceDVB.user195,
+)))
+
+service_types_radio_ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory, eServiceReferenceDVB.dRadio)
+service_types_radio_ref.setPath(makeServiceQueryStr((
+	eServiceReferenceDVB.dRadio,
+	eServiceReferenceDVB.dRadioAvc,
+)))
+
+
+def serviceRefAppendPath(sref, path):
+	nsref = eServiceReference(sref)
+	nsref.setPath(nsref.getPath() + path)
+	return nsref
+
+
+def hdmiInServiceRef():
+	return eServiceReference(eServiceReference.idServiceHDMIIn, eServiceReference.noFlags, eServiceReferenceDVB.dTv)

--- a/lib/python/Tools/Makefile.am
+++ b/lib/python/Tools/Makefile.am
@@ -7,4 +7,4 @@ install_PYTHON = \
 	LoadPixmap.py Profile.py HardwareInfo.py Transponder.py ASCIItranslit.py \
 	Downloader.py Trashcan.py GetEcmInfo.py Alternatives.py TextBoundary.py \
 	camcontrol.py CountryCodes.py MultiBoot.py FallbackTimer.py Hex2strColor.py \
-	Geolocation.py CopyFiles.py AVHelper.py Conversions.py
+	Geolocation.py CopyFiles.py AVHelper.py Conversions.py ServiceReference.py

--- a/lib/python/Tools/ServiceReference.py
+++ b/lib/python/Tools/ServiceReference.py
@@ -1,0 +1,130 @@
+from enigma import eServiceReference, eServiceReferenceDVB, eServiceCenter, getBestPlayableServiceReference
+from Components.config import config
+import NavigationInstance
+
+
+class ServiceReference(eServiceReference):
+	def __init__(self, ref, reftype=eServiceReference.idInvalid, flags=0, path=''):
+		if reftype != eServiceReference.idInvalid:
+			self.ref = eServiceReference(reftype, flags, path)
+		elif not isinstance(ref, eServiceReference):
+			self.ref = eServiceReference(ref or "")
+		else:
+			self.ref = ref
+		self.serviceHandler = eServiceCenter.getInstance()
+
+	def __str__(self):
+		return self.ref.toString()
+
+	def getServiceName(self):
+		info = self.info()
+		return info and info.getName(self.ref) or ""
+
+	def info(self):
+		return self.serviceHandler.info(self.ref)
+
+	def list(self):
+		return self.serviceHandler.list(self.ref)
+
+	def getType(self):
+		return self.ref.type
+
+	def getPath(self):
+		return self.ref.getPath()
+
+	def getFlags(self):
+		return self.ref.flags
+
+	def isRecordable(self):
+		ref = self.ref
+		return ref.flags & eServiceReference.isGroup or (ref.type == eServiceReference.idDVB or ref.type == eServiceReference.idDVB + 0x100 or ref.type == 0x2000 or ref.type == 0x1001)
+
+
+def getStreamRelayRef(sref):
+	try:
+		if "http" in sref:
+			icamport = config.misc.softcam_streamrelay_port.value
+			icamip = ".".join("%d" % d for d in config.misc.softcam_streamrelay_url.value)
+			icam = f"http%3a//{icamip}%3a{icamport}/"
+			if icam in sref:
+				return sref.split(icam)[1].split(":")[0].replace("%3a", ":"), True
+	except Exception:
+		pass
+	return sref, False
+
+
+def getPlayingref(ref):
+	playingref = None
+	if NavigationInstance.instance:
+		playingref = NavigationInstance.instance.getCurrentlyPlayingServiceReference()
+		if playingref:
+			from Screens.InfoBarGenerics import streamrelay  # needs here to prevent cycle import
+			if streamrelay.checkService(playingref):
+				playingref.setAlternativeUrl(playingref.toString())
+	if not playingref:
+		playingref = eServiceReference()
+	return playingref
+
+
+def isPlayableForCur(ref):
+	info = eServiceCenter.getInstance().info(ref)
+	return info and info.isPlayable(ref, getPlayingref(ref))
+
+
+def resolveAlternate(ref):
+	nref = None
+	if ref.flags & eServiceReference.isGroup:
+		nref = getBestPlayableServiceReference(ref, getPlayingref(ref))
+		if not nref:
+			nref = getBestPlayableServiceReference(ref, eServiceReference(), True)
+	return nref
+
+
+def makeServiceQueryStr(serviceTypes):
+	return ' || '.join(['(type == %d)' % x for x in serviceTypes])
+
+
+# type 1 = digital television service
+# type 4 = nvod reference service (NYI)
+# type 17 = MPEG-2 HD digital television service
+# type 22 = advanced codec SD digital television
+# type 24 = advanced codec SD NVOD reference service (NYI)
+# type 25 = advanced codec HD digital television
+# type 27 = advanced codec HD NVOD reference service (NYI)
+# type 2 = digital radio sound service
+# type 10 = advanced codec digital radio sound service
+# type 31 = High Efficiency Video Coding digital television
+# type 32 = High Efficiency Video Coding digital television
+
+# Generate an eServiceRef query path containing
+# '(type == serviceTypes[0]) || (type == serviceTypes[1]) || ...'
+
+
+service_types_tv_ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory, eServiceReferenceDVB.dTv)
+
+service_types_tv_ref.setPath(makeServiceQueryStr((
+	eServiceReferenceDVB.dTv,
+	eServiceReferenceDVB.mpeg2HdTv,
+	eServiceReferenceDVB.avcSdTv,
+	eServiceReferenceDVB.avcHdTv,
+	eServiceReferenceDVB.nvecTv,
+	eServiceReferenceDVB.nvecTv20,
+	eServiceReferenceDVB.user134,
+	eServiceReferenceDVB.user195,
+)))
+
+service_types_radio_ref = eServiceReference(eServiceReference.idDVB, eServiceReference.flagDirectory, eServiceReferenceDVB.dRadio)
+service_types_radio_ref.setPath(makeServiceQueryStr((
+	eServiceReferenceDVB.dRadio,
+	eServiceReferenceDVB.dRadioAvc,
+)))
+
+
+def serviceRefAppendPath(sref, path):
+	nsref = eServiceReference(sref)
+	nsref.setPath(nsref.getPath() + path)
+	return nsref
+
+
+def hdmiInServiceRef():
+	return eServiceReference(eServiceReference.idServiceHDMIIn, eServiceReference.noFlags, eServiceReferenceDVB.dTv)

--- a/lib/service/iservice.h
+++ b/lib/service/iservice.h
@@ -17,14 +17,20 @@ class eServiceReference
 public:
 	enum
 	{
-		idInvalid=-1,
-		idStructure,	// service_id == 0 is root
-		idDVB,
-		idFile,
-		idServiceM2TS= 0x0003,	//    3
-		idUser=0x1000,
-		idServiceMP3=0x1001,
-		idServiceDVD= 0x1111,	// 4369
+		idServiceIsScrambled  = 0x0100,				//  256  Added to normal id to indicate scrambling
+		idInvalid             = -1,
+		idStructure           = 0x0000,				//    0 service_id == 0 is root
+		idDVB                 = 0x0001,				//    1
+		idFile                = 0x0002,				//    2
+		idServiceM2TS         = 0x0003,				//    3
+		idDVBScrambled        = idDVB + idServiceIsScrambled,	//  257/0x0101
+		idUser                = 0x1000,				// 4096
+		idServiceMP3          = 0x1001,				// 4097
+		idServiceAirPlay      = 0x1009,				// 4105
+		idServiceXINE         = 0x1010,				// 4112
+		idServiceDVD          = 0x1111,				// 4369
+		idServiceAzBox        = 0x1112,                         // 4370
+		idServiceHDMIIn       = 0x2000,				// 8192
 	};
 	int type;
 
@@ -112,7 +118,7 @@ public:
 		memset(data, 0, sizeof(data));
 		number = 0;
 	}
-#ifndef SWIG
+
 	eServiceReference(int type, int flags)
 		: type(type), flags(flags)
 	{
@@ -164,22 +170,27 @@ public:
 		data[4]=data4;
 		number = 0;
 	}
-	operator bool() const
-	{
-		return valid();
-	}
-#endif
+
 	eServiceReference(int type, int flags, const std::string &path)
 		: type(type), flags(flags), path(path)
 	{
 		memset(data, 0, sizeof(data));
 		number = 0;
 	}
+#ifdef SWIG
+	eServiceReference(const eServiceReference &ref);
+#endif
 	eServiceReference(const std::string &string);
 	std::string toString() const;
 	std::string toCompareString() const;
 	std::string toReferenceString() const;
 	std::string toLCNReferenceString(bool trailing=true) const;
+#ifndef SWIG
+	operator bool() const
+	{
+		return valid();
+	}
+#endif
 	bool operator==(const eServiceReference &c) const
 	{
 		if (!c || type != c.type)

--- a/lib/service/servicedvb.cpp
+++ b/lib/service/servicedvb.cpp
@@ -2088,27 +2088,12 @@ int eDVBServicePlay::getInfo(int w)
 	case sAudioPID:
 		if (m_dvb_service)
 		{
-			int apid = m_dvb_service->getCacheEntry(eDVBService::cMPEGAPID);
-			if (apid != -1)
-				return apid;
-			apid = m_dvb_service->getCacheEntry(eDVBService::cAC3PID);
-			if (apid != -1)
-				return apid;
-			apid = m_dvb_service->getCacheEntry(eDVBService::cAC4PID);
-			if (apid != -1)
-				return apid;
-			apid = m_dvb_service->getCacheEntry(eDVBService::cDDPPID);
-			if (apid != -1)
-				return apid;
-			apid = m_dvb_service->getCacheEntry(eDVBService::cAACHEAPID);
-			if (apid != -1)
-				return apid;
-			apid = m_dvb_service->getCacheEntry(eDVBService::cAACAPID);
-			if (apid != -1)
-				return apid;
-			apid = m_dvb_service->getCacheEntry(eDVBService::cDRAAPID);
-			if (apid != -1)
-				return apid;
+			for(int m = 0; m < eDVBService::nAudioCacheTags; m++)
+			{
+				int apid = m_dvb_service->getCacheEntry(eDVBService::audioCacheTags[m]);
+				if (apid != -1)
+					return apid;
+			}
 		}
 		if (no_program_info) return -1;
 		if (program.audioStreams.empty()) return -1;
@@ -2277,28 +2262,31 @@ RESULT eDVBServicePlay::getTrackInfo(struct iAudioTrackInfo &info, unsigned int 
 
 	info.m_pid = program.audioStreams[i].pid;
 
-	if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atMPEG)
-		info.m_description = "MPEG";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atAC3)
-		info.m_description = "AC3";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atAC4)
-		info.m_description = "AC4";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atDDP)
-		info.m_description = "AC3+";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atAAC)
-		info.m_description = "AAC";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atAACHE)
-		info.m_description = "AAC-HE";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atDTS)
-		info.m_description = "DTS";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atDTSHD)
-		info.m_description = "DTS-HD";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atLPCM)
-		info.m_description = "LPCM";
-	else if (program.audioStreams[i].type == eDVBServicePMTHandler::audioStream::atDRA)
-		info.m_description = "DRA";
-	else
-		info.m_description = "???";
+	const static struct {
+		int streamType;
+		char const* typeName;
+	} audioMap [] = {
+		{ eDVBServicePMTHandler::audioStream::atMPEG,  "MPEG",   },
+		{ eDVBServicePMTHandler::audioStream::atAC3,   "AC3",    },
+		{ eDVBServicePMTHandler::audioStream::atDDP,   "AC3+",   },
+		{ eDVBServicePMTHandler::audioStream::atAC4,   "AC4",    },
+		{ eDVBServicePMTHandler::audioStream::atAAC,   "AAC",    },
+		{ eDVBServicePMTHandler::audioStream::atDRA,   "DRA",    },
+		{ eDVBServicePMTHandler::audioStream::atAACHE, "AAC-HE", },
+		{ eDVBServicePMTHandler::audioStream::atDTS,   "DTS",    },
+		{ eDVBServicePMTHandler::audioStream::atDTSHD, "DTS-HD", },
+		{ eDVBServicePMTHandler::audioStream::atLPCM,  "LPCM",   },
+	};
+	static const int nAudioMap = sizeof audioMap / sizeof audioMap[0];
+	info.m_description = "???";
+	for(int m = 0; m < nAudioMap; m++)
+	{
+		if (program.audioStreams[m].type == audioMap[m].streamType)
+		{
+			info.m_description = audioMap[i].typeName;
+			break;
+		}
+	}
 
 	if (program.audioStreams[i].component_tag != -1)
 	{
@@ -2396,22 +2384,29 @@ int eDVBServicePlay::selectAudioStream(int i)
 				d.) we have only one audiostream (overwrite the cache to make sure
 					the cache contains the correct audio pid and type)
 			*/
-	if (m_dvb_service && ((i != -1) || (program.audioStreams.size() == 1)
-		|| ((m_dvb_service->getCacheEntry(eDVBService::cMPEGAPID) == -1)
-		&& (m_dvb_service->getCacheEntry(eDVBService::cAC3PID)== -1)
-		&& (m_dvb_service->getCacheEntry(eDVBService::cAC4PID)== -1)
-		&& (m_dvb_service->getCacheEntry(eDVBService::cDDPPID)== -1)
-		&& (m_dvb_service->getCacheEntry(eDVBService::cAACHEAPID) == -1)
-		&& (m_dvb_service->getCacheEntry(eDVBService::cAACAPID) == -1)
-		&& (m_dvb_service->getCacheEntry(eDVBService::cDRAAPID) == -1))))
+	if (m_dvb_service && (i != -1 || program.audioStreams.size() == 1
+		|| m_dvb_service->cacheAudioEmpty()))
 	{
-		m_dvb_service->setCacheEntry(eDVBService::cMPEGAPID, apidtype == eDVBAudio::aMPEG ? apid : -1);
-		m_dvb_service->setCacheEntry(eDVBService::cAC3PID, apidtype == eDVBAudio::aAC3 ? apid : -1);
-		m_dvb_service->setCacheEntry(eDVBService::cAC4PID, apidtype == eDVBAudio::aAC4 ? apid : -1);
-		m_dvb_service->setCacheEntry(eDVBService::cDDPPID, apidtype == eDVBAudio::aDDP ? apid : -1);
-		m_dvb_service->setCacheEntry(eDVBService::cAACHEAPID, apidtype == eDVBAudio::aAACHE ? apid : -1);
-		m_dvb_service->setCacheEntry(eDVBService::cAACAPID, apidtype == eDVBAudio::aAAC ? apid : -1);
-		m_dvb_service->setCacheEntry(eDVBService::cDRAAPID, apidtype == eDVBAudio::aDRA ? apid : -1);
+		const static struct {
+			int streamType;
+			eDVBService::cacheID cacheTag;
+		} audioMap [] = {
+			{ eDVBAudio::aMPEG,  eDVBService::cMPEGAPID,  },
+			{ eDVBAudio::aAC3,   eDVBService::cAC3PID,    },
+			{ eDVBAudio::aAC4,   eDVBService::cAC4PID,    },
+			{ eDVBAudio::aDDP,   eDVBService::cDDPPID,    },
+			{ eDVBAudio::aAAC,   eDVBService::cAACAPID,   },
+			{ eDVBAudio::aDTS,   eDVBService::cDTSPID,    },
+			{ eDVBAudio::aLPCM,  eDVBService::cLPCMPID,   },
+			{ eDVBAudio::aDTSHD, eDVBService::cDTSHDPID,  },
+			{ eDVBAudio::aAACHE, eDVBService::cAACHEAPID, },
+			{ eDVBAudio::aDRA,   eDVBService::cDRAAPID,   },
+		};
+		static const int nAudioMap = sizeof audioMap / sizeof audioMap[0];
+		for(int m = 0; m < nAudioMap; m++)
+		{
+			m_dvb_service->setCacheEntry(audioMap[m].cacheTag, apidtype == audioMap[m].streamType ? apid : -1);
+		}
 	}
 
 	h.resetCachedProgram();

--- a/lib/service/servicedvbrecord.cpp
+++ b/lib/service/servicedvbrecord.cpp
@@ -233,10 +233,11 @@ int eDVBServiceRecord::doPrepare()
 				/*
 				* streams are considered to be descrambled by default;
 				* user can indicate a stream is scrambled, by using servicetype id + 0x100
+				* (or idDVB + idServiceIsScrambled == idDVBScrambled)
 				*/
 				bool config_descramble_client = eConfigManager::getConfigBoolValue("config.streaming.descramble_client", false);
 
-				m_descramble = (m_ref.type == eServiceFactoryDVB::id + 0x100);
+				m_descramble = (m_ref.type == eServiceReference::idDVBScrambled);
 
 				if(config_descramble_client)
 					m_descramble = true;

--- a/lib/service/servicefs.h
+++ b/lib/service/servicefs.h
@@ -9,7 +9,7 @@ class eServiceFactoryFS: public iServiceHandler
 public:
 	eServiceFactoryFS();
 	virtual ~eServiceFactoryFS();
-	enum { id = 0x2 };
+	enum { id = eServiceReference::idFile };
 
 		// iServiceHandler
 	RESULT play(const eServiceReference &, ePtr<iPlayableService> &ptr);

--- a/lib/service/servicehdmi.h
+++ b/lib/service/servicehdmi.h
@@ -13,7 +13,7 @@ class eServiceFactoryHDMI: public iServiceHandler
 public:
 	eServiceFactoryHDMI();
 	virtual ~eServiceFactoryHDMI();
-	enum { id = 0x2000 };
+	enum { id = eServiceReference::idServiceHDMIIn };
 
 	RESULT play(const eServiceReference &, ePtr<iPlayableService> &ptr);
 	RESULT record(const eServiceReference &, ePtr<iRecordableService> &ptr);

--- a/lib/service/servicexine.h
+++ b/lib/service/servicexine.h
@@ -17,7 +17,7 @@ class eServiceFactoryXine: public iServiceHandler
 public:
 	eServiceFactoryXine();
 	virtual ~eServiceFactoryXine();
-	enum { id = 0x1010 };
+	enum { id = eServiceReference::idServiceXINE };
 
 		// iServiceHandler
 	RESULT play(const eServiceReference &, ePtr<iPlayableService> &ptr);


### PR DESCRIPTION
In [ServiceInfo] check whether the current service is HDMI IN and
return an empty string for VideoInfo if it is.

Return appropriate values for ServiceInfo data in other cases where
the current serviice is HDMI IN.

Also added idServiceHDMIIn serviceref type to eServiceReference
(lib/service/iservice.h).

Restore code in eServiceHDMI::getInfoString(int w) to return the
serviceref string that was introduced in commit https://github.com/openatv/enigma2/commit/bd0e4d0865a6ae4c7ad38e0981e594674c7596d7 and removed
when commit https://github.com/openatv/enigma2/commit/71736554d10cf43d9f754a58fc7af7dd5520d78a reversed commit https://github.com/openatv/enigma2/commit/1eb2f31ff148b066a96a366b3b7df1420b741b96.

Replaced some if statements with if expressions.

[ServiceInfo.py] Add additional video information (https://github.com/openatv/enigma2/pull/78)

This change adds three additional video information items "Freq_Info", "Progressive" and "VideoInfo".

The code has also been optimised and tidied up to remove code duplication.

eServiceReference cleanup

First stage of a cleanup of the use of eServiceReference, especially
to reduce the use of numbers for eServiceReference parameters and
the reduce the use of creation and manipulation of eServiceReferences
in theit string format.

New:

Tools/ServiceReference.py
	Some useful functions and global definitions of service
	reference that didn't fit easily elsewhere.

Modified:

RecordTimer.py
	Use eServiceReferences instead of the equivalent string
	expressions where possible.
	Use some global eServiceReferences from Tools/ServiceReference.py.
	Update the status of the old string expressions for at least
	read backward compatibility.
	Affects Zap timers and the warnings given when a zap is
	forced by all tuners being used for recordings.

lib/python/Screens/ChannelSelection.py
	Use eServiceReferences instead of the equivalent string
	expressions where possible.
	Use some global eServiceReferences from Tools/ServiceReference.py.
	Update the status of the old string expressions for at least
	read backward compatibility.
	Affects:
		adding markers to bouquets;
		add alternatives;
		add new bouquet;
		TV/RADIO entries to ChannelSelection with multiple
		bouquets enabled/disabled;
		RED All to show all services;
		GREEN Satellites to show satellite services (which
		also shows terrestrial services);
		YELLOW Providers to show individual broadcast
		channels as bouquets;
		adding services to bouquets;
		CH+/- to switch between bouquets;
		FAV to show channel list; and
		using OK to select and "play" a channel
		(gotoCurrentServiceOrProvider()).

lib/python/Screens/InfoBarGenerics.py
	Use eServiceReferences instead of the equivalent string
	expressions where possible (for HDMI in).
	Use the symbolic service reference type for HDMI IN instead
	of 8192.
	Affects HDMI IN for PiP and full screen mode from BLUE menu
	in live TV.

lib/python/Screens/Menu.py
	Removed unused imports of eServiceReference and iServiceInformation
	from enigma.

lib/dvb/idvb.h
	Add an enum to give symbolic values for eServiceID.
	Open the definition of eServiceReferenceDVB and the classes
	it uses to access from Python.
	Use symbolic names from eServiceReferenceDVB and eServiceID
	for constants instead of numbers.

lib/service/iservice.h
	More comprehensive set of symbolic names for service reference
	types.
	A noFlags name for 0 in the flags enum.
	Make all constructors accessible from Python.
	Define the copy constructor for SWIG so that the copy
	constructor can be used instead of the constructor from
	string in many contexts in the Python code.
	Move bool type converter operator to group with the other
	operators.

lib/service/servicedvb.h
lib/service/servicedvd.h
lib/service/servicefs.h
lib/service/servicehdmi.h
lib/service/servicem2ts.h
lib/service/servicemp3.h
lib/service/servicexine.h
	Use symbolic names for service types defined in eServiceReference
	in the eServiceFactory* 'id' enums instead of re-defining
	the ids with numbers.

lib/service/servicefs.cpp
	Use the explict eServiceReference::noFlags symbol instead
	of 0 for empty flags.

lib/service/servicedvbrecord.cpp
	Replace eServiceFactoryDVB::id + 0x100 with the symbolic
	equivalent eServiceReference::idDVBScrambled.

doc/SERVICEREF
	Update with new service reference types and DVB service types.
	Add description of DVB search paths.
	Other minor fixes.

cherry-pick > https://github.com/openatv/enigma2/commit/70341f6e2ab17a63f7c7d27f859722d65a678ebc