### PR TITLE
E2-DarkOS skin: missing commits

### DIFF
--- a/lib/python/skin.py
+++ b/lib/python/skin.py
@@ -604,12 +604,13 @@ def parseParameter(value):
 		return int(value)
 
 
-def parsePixmap(path, desktop):
+def parsePixmap(path, desktop, width=0, height=0):
 	option = path.find("#")
 	if option != -1:
 		path = path[:option]
 	if isfile(path):
-		pixmap = LoadPixmap(path, desktop=desktop)
+		# width/height are only consumed by the SVG rasterizer; raster loaders ignore them.
+		pixmap = LoadPixmap(path, desktop=desktop, width=width, height=height)
 		if pixmap is None:
 			skinError(f"Pixmap file '{path}' could not be loaded")
 	else:
@@ -930,7 +931,8 @@ class AttributeParser:
 		self.scaleTuple = scale
 
 	def applyAll(self, attributes):
-		# attributes.sort(key=lambda x: {"pixmap": 1}.get(x[0], 0))  # For SVG pixmap scale required the size, so sort pixmap last.
+		# Apply 'pixmap' last so 'size' is already set when SVGs rasterize.
+		attributes.sort(key=lambda x: {"pixmap": 1}.get(x[0], 0))
 		for attribute, value in attributes:
 			self.applyOne(attribute, value)
 
@@ -1153,7 +1155,10 @@ class AttributeParser:
 		self.guiObject.setPadding(eRect(self.applyHorizontalScale(leftPadding), self.applyVerticalScale(topPadding), self.applyHorizontalScale(rightPadding), self.applyVerticalScale(bottomPadding)))
 
 	def pixmap(self, value):
-		self.guiObject.setPixmap(parsePixmap(value, self.desktop))
+		if value.endswith(".svg"):  # SVG rasterizes to RGBA — force alpha-blend.
+			self.guiObject.setAlphatest(BT_ALPHABLEND)
+		size = self.guiObject.size()
+		self.guiObject.setPixmap(parsePixmap(value, self.desktop, size.width(), size.height()))
 
 	def pointer(self, value):
 		(name, pos) = (x.strip() for x in value.split(":", 1))

--- a/lib/service/listboxservice.cpp
+++ b/lib/service/listboxservice.cpp
@@ -1150,13 +1150,27 @@ void eListboxServiceContent::paint(gPainter &painter, eWindowStyle &style, const
 					eRect area = m_element_position[e == celFolderPixmap ? celServiceName: celServiceNumber];
 					if (m_show_two_lines)
 						area.setHeight(m_itemsize.height());
-					int correction = (m_itemsize.height() - pixmap_size.height()) / 2;
 					if (e == celFolderPixmap && m_element_position[celServiceEventProgressbar].left() == m_element_position[celServiceNumber].left())
 						area.setLeft(m_element_position[celServiceNumber].left());
-					xoffset = pixmap_size.width() + m_items_distances;
 					area.moveBy(offset);
 					painter.clip(area);
-					painter.blit(pixmap, ePoint(area.left(), offset.y() + correction), area, gPainter::BT_ALPHABLEND);
+					if (pixmap_size.height() > m_itemsize.height())
+					{
+						// Source pixmap is taller than the item (e.g. an 80x80 folder.png while bouquet items are ~50 px tall).
+						// Scale-fit into a square slot of itemheight, keeping aspect ratio, instead of letting the clip cut the lower half of the icon off.
+						int slot = m_itemsize.height();
+						xoffset = slot + m_items_distances;
+						painter.blitScale(pixmap,
+							eRect(area.left(), offset.y(), slot, slot),
+							area,
+							gPainter::BT_ALPHABLEND | gPainter::BT_KEEP_ASPECT_RATIO | gPainter::BT_HALIGN_CENTER | gPainter::BT_VALIGN_CENTER);
+					}
+					else
+					{
+						int correction = (m_itemsize.height() - pixmap_size.height()) / 2;
+						xoffset = pixmap_size.width() + m_items_distances;
+						painter.blit(pixmap, ePoint(area.left(), offset.y() + correction), area, gPainter::BT_ALPHABLEND);
+					}
 					painter.clippop();
 				}
 			}


### PR DESCRIPTION
[skin] Pass widget size to parsePixmap so SVGs rasterize at the right scale
[listboxservice] Scale-fit oversized folder/marker pixmaps to item height
